### PR TITLE
[Feat/#4] 비행 전 화면 구조 구현

### DIFF
--- a/Orum/Orum.xcodeproj/project.pbxproj
+++ b/Orum/Orum.xcodeproj/project.pbxproj
@@ -19,6 +19,8 @@
 		933A8E4E2ADD1AB2002AE727 /* TripDateSettingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A8E4D2ADD1AB2002AE727 /* TripDateSettingView.swift */; };
 		933A8E502ADD1AF6002AE727 /* TripRemainingDayView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A8E4F2ADD1AF6002AE727 /* TripRemainingDayView.swift */; };
 		933A8E522ADD1B2E002AE727 /* FlightInfoSubmitView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 933A8E512ADD1B2E002AE727 /* FlightInfoSubmitView.swift */; };
+		93F68C7A2AE0492E00B96F5C /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F68C792AE0492E00B96F5C /* NavigationManager.swift */; };
+		93F68C7C2AE04B6600B96F5C /* DepartRemainingTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F68C7B2AE04B6600B96F5C /* DepartRemainingTimeView.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -36,6 +38,8 @@
 		933A8E4D2ADD1AB2002AE727 /* TripDateSettingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripDateSettingView.swift; sourceTree = "<group>"; };
 		933A8E4F2ADD1AF6002AE727 /* TripRemainingDayView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TripRemainingDayView.swift; sourceTree = "<group>"; };
 		933A8E512ADD1B2E002AE727 /* FlightInfoSubmitView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightInfoSubmitView.swift; sourceTree = "<group>"; };
+		93F68C792AE0492E00B96F5C /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
+		93F68C7B2AE04B6600B96F5C /* DepartRemainingTimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepartRemainingTimeView.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -95,6 +99,7 @@
 				933A8E4D2ADD1AB2002AE727 /* TripDateSettingView.swift */,
 				933A8E4F2ADD1AF6002AE727 /* TripRemainingDayView.swift */,
 				933A8E512ADD1B2E002AE727 /* FlightInfoSubmitView.swift */,
+				93F68C7B2AE04B6600B96F5C /* DepartRemainingTimeView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -103,6 +108,7 @@
 			isa = PBXGroup;
 			children = (
 				930F26DB2ADD0F3D00896A32 /* Model.swift */,
+				93F68C792AE0492E00B96F5C /* NavigationManager.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -195,9 +201,11 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				93F68C7A2AE0492E00B96F5C /* NavigationManager.swift in Sources */,
 				930F26E02ADD0F6A00896A32 /* ViewModel.swift in Sources */,
 				933A8E522ADD1B2E002AE727 /* FlightInfoSubmitView.swift in Sources */,
 				930F26DC2ADD0F3D00896A32 /* Model.swift in Sources */,
+				93F68C7C2AE04B6600B96F5C /* DepartRemainingTimeView.swift in Sources */,
 				933A8E4E2ADD1AB2002AE727 /* TripDateSettingView.swift in Sources */,
 				933A8E4A2ADD1A53002AE727 /* Date+RawValue.swift in Sources */,
 				930F26CB2ADD0D8B00896A32 /* ContentView.swift in Sources */,

--- a/Orum/Orum/Models/NavigationManager.swift
+++ b/Orum/Orum/Models/NavigationManager.swift
@@ -1,0 +1,19 @@
+//
+//  NavigationManager.swift
+//  Orum
+//
+//  Created by 차차 on 10/19/23.
+//
+
+import SwiftUI
+
+final class NavigationManager: ObservableObject {
+    enum ViewCycle: String { // TODO: 교육 컨텐츠 화면에 해당하는 뷰 사이클 생성하기
+        case first // 여행 일자 입력 전
+        case second // 여행 일자 입력 후 && 여행 일자 이전
+        case third // 여행 일자 당일 이후 && 운항 정보 입력 이전
+        case fourth // 운항 정보 입력 이후
+    }
+    
+    @AppStorage("viewCycle") var viewCycle: ViewCycle = .first
+}

--- a/Orum/Orum/OrumApp.swift
+++ b/Orum/Orum/OrumApp.swift
@@ -9,10 +9,23 @@ import SwiftUI
 
 @main
 struct OrumApp: App {
+    @StateObject private var navigationManager = NavigationManager()
     var body: some Scene {
         WindowGroup {
-            // ContentView()
-            TripDateSettingView()
+            switch navigationManager.viewCycle {
+            case .first:
+                TripDateSettingView()
+                    .environmentObject(navigationManager)
+            case .second:
+                TripRemainingDayView()
+                    .environmentObject(navigationManager)
+            case .third:
+                FlightInfoSubmitView()
+                    .environmentObject(navigationManager)
+            case .fourth:
+                DepartRemainingTimeView()
+                    .environmentObject(navigationManager)
+            }
         }
     }
 }

--- a/Orum/Orum/Views/DepartRemainingTimeView.swift
+++ b/Orum/Orum/Views/DepartRemainingTimeView.swift
@@ -1,0 +1,18 @@
+//
+//  DepartRemainingTimeView.swift
+//  Orum
+//
+//  Created by 차차 on 10/19/23.
+//
+
+import SwiftUI
+
+struct DepartRemainingTimeView: View {
+    var body: some View {
+        Text("출발까지 남은 시간 표시")
+    }
+}
+
+#Preview {
+    DepartRemainingTimeView()
+}

--- a/Orum/Orum/Views/FlightInfoSubmitView.swift
+++ b/Orum/Orum/Views/FlightInfoSubmitView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct FlightInfoSubmitView: View {
     var body: some View {
-        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+        Text("운항 정보 입력 뷰")
     }
 }
 

--- a/Orum/Orum/Views/TripDateSettingView.swift
+++ b/Orum/Orum/Views/TripDateSettingView.swift
@@ -10,7 +10,7 @@ import SwiftUI
 struct TripDateSettingView: View {
     @State var today = Date()
     @AppStorage("dDay") var dDay: Date = Date()
-    
+    @EnvironmentObject var navigationManager: NavigationManager
     let dateFormatter = DateFormatter()
     
     var body: some View {
@@ -27,12 +27,20 @@ struct TripDateSettingView: View {
                 
                 if remainingDay != 0 {
                     NavigationLink(destination: TripRemainingDayView()) {
-                        Text("Next")
+                        Button (action: {
+                            navigationManager.viewCycle = .second
+                        }){
+                            Text("Next")
+                        }
                     }
                 }
                 else {
                     NavigationLink(destination: FlightInfoSubmitView()) {
-                        Text("Next")
+                        Button (action: {
+                            navigationManager.viewCycle = .third
+                        }){
+                            Text("Next")
+                        }
                     }
                 }
             }

--- a/Orum/Orum/Views/TripRemainingDayView.swift
+++ b/Orum/Orum/Views/TripRemainingDayView.swift
@@ -15,9 +15,6 @@ struct TripRemainingDayView: View {
         let remainingDay = Calendar.current.compareDays(today, and: dDay)
         
         Text("D - \(remainingDay) until Trip")
-            .onAppear() {
-                print(remainingDay)
-            }
     }
 }
 


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->
- 비행 전 화면들의 구조를 구현했습니다.
- 작업 이슈: #4 

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->
- 비행 전 화면들의 구조를 구현했습니다.
- 사용자가 입력한 정보와 시기에 따라 앱의 진입 화면이 달라지므로 이를 @AppStorage를 통해 앱 내에 저장합니다.
## Logic
<!-- 작업 내용 1 -->
```swift
import SwiftUI

final class NavigationManager: ObservableObject {
    enum ViewCycle: String { // TODO: 교육 컨텐츠 화면에 해당하는 뷰 사이클 생성하기
        case first // 여행 일자 입력 전
        case second // 여행 일자 입력 후 && 여행 일자 이전
        case third // 여행 일자 당일 이후 && 운항 정보 입력 이전
        case fourth // 운항 정보 입력 이후
    }
    
    @AppStorage("viewCycle") var viewCycle: ViewCycle = .first
}

```

 ## 작업 결과(이미지 첨부는 선택)
- 현재 화면 간의 전환이 조금 부자연스러워서 이후에 이를 해결 할 수 있는 방법에 대해 논의가 필요할 것 같습니다.
