### PR TITLE
[Feat/#15] ChapterView 구현 완료

### DIFF
--- a/Orum/Orum.xcodeproj/project.pbxproj
+++ b/Orum/Orum.xcodeproj/project.pbxproj
@@ -25,6 +25,8 @@
 		D950CF632AE1277600BD9EB3 /* FlightCodeAPIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D950CF622AE1277600BD9EB3 /* FlightCodeAPIManager.swift */; };
 		D950CF652AE127C600BD9EB3 /* FlightCodeAPIData.swift in Sources */ = {isa = PBXBuildFile; fileRef = D950CF642AE127C600BD9EB3 /* FlightCodeAPIData.swift */; };
 		D950CF672AE1283B00BD9EB3 /* FlightInfo.swift in Sources */ = {isa = PBXBuildFile; fileRef = D950CF662AE1283B00BD9EB3 /* FlightInfo.swift */; };
+		D95E209A2AE52FC50062F3EB /* ConsonantChapterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D95E20992AE52FC50062F3EB /* ConsonantChapterView.swift */; };
+		D95E209C2AE54D1F0062F3EB /* ConsonantChapterContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D95E209B2AE54D1F0062F3EB /* ConsonantChapterContentView.swift */; };
 		D967D1BD2AE2932C008B3379 /* HangulCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D967D1BC2AE2932C008B3379 /* HangulCard.swift */; };
 		D967D1C12AE2A968008B3379 /* HangulUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D967D1C02AE2A968008B3379 /* HangulUnit.swift */; };
 		D967D1C32AE2BD83008B3379 /* ConsonantCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D967D1C22AE2BD83008B3379 /* ConsonantCardView.swift */; };
@@ -54,6 +56,8 @@
 		D950CF622AE1277600BD9EB3 /* FlightCodeAPIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightCodeAPIManager.swift; sourceTree = "<group>"; };
 		D950CF642AE127C600BD9EB3 /* FlightCodeAPIData.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightCodeAPIData.swift; sourceTree = "<group>"; };
 		D950CF662AE1283B00BD9EB3 /* FlightInfo.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightInfo.swift; sourceTree = "<group>"; };
+		D95E20992AE52FC50062F3EB /* ConsonantChapterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsonantChapterView.swift; sourceTree = "<group>"; };
+		D95E209B2AE54D1F0062F3EB /* ConsonantChapterContentView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsonantChapterContentView.swift; sourceTree = "<group>"; };
 		D967D1BC2AE2932C008B3379 /* HangulCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulCard.swift; sourceTree = "<group>"; };
 		D967D1C02AE2A968008B3379 /* HangulUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulUnit.swift; sourceTree = "<group>"; };
 		D967D1C22AE2BD83008B3379 /* ConsonantCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsonantCardView.swift; sourceTree = "<group>"; };
@@ -123,6 +127,8 @@
 				93F68C7B2AE04B6600B96F5C /* DepartRemainingTimeView.swift */,
 				D967D1C22AE2BD83008B3379 /* ConsonantCardView.swift */,
 				D967D1C42AE2BE81008B3379 /* ConsonantCardContentView.swift */,
+				D95E20992AE52FC50062F3EB /* ConsonantChapterView.swift */,
+				D95E209B2AE54D1F0062F3EB /* ConsonantChapterContentView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -231,6 +237,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				D95E209A2AE52FC50062F3EB /* ConsonantChapterView.swift in Sources */,
 				D967D1C72AE2C761008B3379 /* UIColor+Hex.swift in Sources */,
 				D967D1C92AE40F4E008B3379 /* TTSManager.swift in Sources */,
 				93F68C7A2AE0492E00B96F5C /* NavigationManager.swift in Sources */,
@@ -242,6 +249,7 @@
 				D950CF672AE1283B00BD9EB3 /* FlightInfo.swift in Sources */,
 				D950CF632AE1277600BD9EB3 /* FlightCodeAPIManager.swift in Sources */,
 				933A8E4E2ADD1AB2002AE727 /* TripDateSettingView.swift in Sources */,
+				D95E209C2AE54D1F0062F3EB /* ConsonantChapterContentView.swift in Sources */,
 				933A8E4A2ADD1A53002AE727 /* Date+RawValue.swift in Sources */,
 				930F26CB2ADD0D8B00896A32 /* ContentView.swift in Sources */,
 				D967D1BD2AE2932C008B3379 /* HangulCard.swift in Sources */,

--- a/Orum/Orum/Views/ConsonantCardView.swift
+++ b/Orum/Orum/Views/ConsonantCardView.swift
@@ -16,8 +16,7 @@ struct ConsonantCardView: View {
     @State var checkCount : Int = 0
     @State var nextWordActive: Bool = false
     @State var flipped: Bool = false
-    @State var transitionView: Bool = true
-
+    @State var chapterViewActive: Bool = false
     
     
     var body: some View {
@@ -38,7 +37,7 @@ struct ConsonantCardView: View {
                         }
                         .background(Color.white)
                         .clipShape(RoundedRectangle(cornerRadius: 20.0))
-                        .shadow(radius: 3)
+//                        .shadow(radius: 3)
                         .onTapGesture {
                             previousWord()
                         }
@@ -61,11 +60,11 @@ struct ConsonantCardView: View {
                                         .foregroundStyle(flipCheck ? .blue : Color(UIColor(hex: "D1D1D6")))
                                     
                                 }
-                                .padding(10)
+                                .padding(EdgeInsets(top: 10, leading: 20, bottom: 10, trailing: 20))
                             }
                             .background(Color.white)
                             .clipShape(RoundedRectangle(cornerRadius: 20.0))
-                            .shadow(radius: 3)
+//                            .shadow(radius: 3)
                         } else {
                             ZStack{
                                 HStack{
@@ -77,22 +76,31 @@ struct ConsonantCardView: View {
                                         .font(.system(size: 17))
                                         .foregroundStyle(.white)
                                 }
-                                .padding(10)
+                                .padding(EdgeInsets(top: 10, leading: 20, bottom: 10, trailing: 20))
                             }
                             .background(.blue)
                             .clipShape(RoundedRectangle(cornerRadius: 20.0))
-                            .shadow(radius: 3)
+//                            .shadow(radius: 3)
                             .onTapGesture {
 //                                nextWordActive = true
-                                nextWord()
+                                if hangulUnit.unitIndex + 1 == hangulUnit.hangulCards.count {
+                                    chapterViewActive = true
+                                } else {
+                                    nextWord()
+                                }
                             }
                         }
                     }
                     .padding(.bottom, 20)
                 }
-                .frame(width: UIScreen.main.bounds.size.width - 40)
+                .frame(width: UIScreen.main.bounds.size.width - 30)
             }
             .navigationTitle(hangulUnit.unitName.capitalized)
+            .navigationDestination(isPresented: $chapterViewActive, destination: {
+                ConsonantChapterView(hangulUnit:  HangulUnit(unitName: hangulUnit.unitName, unitIndex: hangulUnit.unitIndex + 1, hangulCards: hangulUnit.hangulCards)
+)
+            })
+            .navigationBarBackButtonHidden()
             .transition(.slide)
         }
     }
@@ -104,7 +112,6 @@ struct ConsonantCardView: View {
             checkCount = 0
             example2Check = false
             flipped = false
-            transitionView = true
         }
     }
     func previousWord() {
@@ -115,7 +122,6 @@ struct ConsonantCardView: View {
             checkCount = 0
             example2Check = false
             flipped = false
-            transitionView.toggle()
         }
     }
 }

--- a/Orum/Orum/Views/ConsonantChapterContentView.swift
+++ b/Orum/Orum/Views/ConsonantChapterContentView.swift
@@ -1,0 +1,65 @@
+//
+//  ConsonantChapterContentView.swift
+//  Orum
+//
+//  Created by Youngbin Choi on 10/22/23.
+//
+
+import SwiftUI
+
+struct ConsonantChapterContentView: View {
+    
+    @State var hangulCard : HangulCard
+    @State var flipCheck : Bool = false
+    @State var checkCount : Int = 0
+    @State var flipped: Bool = false
+    
+    var body: some View {
+        ZStack{
+            VStack(spacing: 10){
+                Image(hangulCard.name)
+                    .resizable()
+                    .padding(EdgeInsets(top: 30, leading: 30, bottom: 0, trailing: 30))
+                    .scaledToFit()
+                ZStack{
+                    Text(hangulCard.sound)
+                        .fontWeight(.bold)
+                        .font(.largeTitle)
+                    Text("[   ]")
+                        .fontWeight(.bold)
+                        .font(.largeTitle)
+                        .foregroundStyle(Color(UIColor(hex: "D1D1D6")))
+                }
+//                .padding(15)
+                Divider()
+                Image(systemName: "lightbulb.circle.fill")
+                    .font(.system(size: 32.0))
+                    .foregroundStyle(.blue)
+                    .padding(5)
+                    .onTapGesture {
+                        if !flipCheck {
+                            checkCount += 1
+                        }
+                        flipped.toggle()
+                        flipCheck = true
+                    }
+                    .overlay {
+                        Circle()
+                            .frame(width: 4)
+                            .offset(y: 20)
+                            .foregroundStyle( flipCheck ? .blue : .clear )
+                    }
+            }
+        }
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 15.0))
+//            .shadow(radius: 3)
+        .rotation3DEffect(flipped ? Angle(degrees: 180) : .zero,
+                          axis: (x: 0.0, y: 1.0, z: 0.0))
+        .animation(.default, value: flipped)
+    }
+}
+
+#Preview {
+    ConsonantChapterContentView(hangulCard: HangulCard(name: "ㄱ", sound: "g", example1: "가", example2: "구", soundExample1: "ga", soundExample2: "gu"))
+}

--- a/Orum/Orum/Views/ConsonantChapterView.swift
+++ b/Orum/Orum/Views/ConsonantChapterView.swift
@@ -1,0 +1,80 @@
+//
+//  ConsonantChapterView.swift
+//  Orum
+//
+//  Created by Youngbin Choi on 10/22/23.
+//
+
+import SwiftUI
+
+struct ConsonantChapterView: View {
+    
+    @State var hangulUnit : HangulUnit
+    
+    var body: some View {
+        NavigationStack{
+            ZStack {
+                Color(uiColor: UIColor(hex: "F2F2F7")).edgesIgnoringSafeArea(.all)
+                VStack{
+                    LazyVGrid(columns: [GridItem(.flexible(), spacing: 15), GridItem(.flexible())], spacing: 15) {
+                        ForEach(0..<hangulUnit.hangulCards.count, id: \.self) { index in
+                            let hangulCard = hangulUnit.hangulCards[index]
+                            ConsonantChapterContentView(hangulCard: hangulCard)
+                        }
+                    }
+                    Spacer()
+                    Divider()
+                        .padding(.vertical, 10)
+                    HStack{
+                        ZStack{
+                            Image(systemName: "arrow.uturn.backward")
+                                .foregroundStyle(.blue)
+                                .font(.system(size: 32.0))
+                                .padding(10)
+                        }
+                        .background(Color.white)
+                        .clipShape(RoundedRectangle(cornerRadius: 15.0))
+//                        .shadow(radius: 3)
+                        .onTapGesture {
+                            print()
+                        }
+                        Spacer()
+                        
+                        ZStack{
+                            HStack{
+                                Image(systemName: "q.circle.fill")
+                                    .font(.system(size: 32.0))
+                                    .foregroundStyle(.white)
+                                Text("Quiz")
+                                    .fontWeight(.bold)
+                                    .font(.system(size: 17))
+                                    .foregroundStyle(.white)
+                            }
+                            .padding(EdgeInsets(top: 10, leading: 20, bottom: 10, trailing: 20))
+                        }
+                        .background(.blue)
+                        .clipShape(RoundedRectangle(cornerRadius: 12.0))
+//                        .shadow(radius: 3)
+                        .onTapGesture {
+                            print()
+                        }
+                    }
+                    .padding(.bottom, 20)
+                    
+                }
+                .frame(width: UIScreen.main.bounds.size.width - 30)
+            }
+            .navigationTitle(hangulUnit.unitName.capitalized)
+            .navigationBarBackButtonHidden()
+        }
+    }
+}
+
+#Preview {
+    ConsonantChapterView(hangulUnit: HangulUnit(unitName: "consonants1", unitIndex: 0, hangulCards: [
+        HangulCard(name: "ㄱ", sound: "g", example1: "가", example2: "구", soundExample1: "ga", soundExample2: "gu"),
+        HangulCard(name: "ㄴ", sound: "n", example1: "나", example2: "누", soundExample1: "na", soundExample2: "nu"),
+        HangulCard(name: "ㄷ", sound: "d", example1: "다", example2: "두", soundExample1: "da", soundExample2: "du"),
+        HangulCard(name: "ㄹ", sound: "r", example1: "라", example2: "루", soundExample1: "ra", soundExample2: "ru")
+    ]))
+}


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->

ChapterView 를 구현하였습니다


## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->

ChapterView UI, 로직 구현하였습니다.
CardView의 카드모양과 ChapterView 의 카드모양이 조금 달라서, ChapterView 카드코드를 새로 작성했습니다.

## Logic
<!-- 작업 내용 1 -->

코드를 작성하다보니, 앞에 CardContentView 코드 리팩토링이 필요해 보이더라구요! 
CardView에서 CardContentView 로 HangulCard 낱장으로 넘겨주면 되는데, 현재는 HangulUnit 전체를 보내는 형식으로 되어 있어서요
챕터뷰는 아래처럼 넘깁니다
```swift
 LazyVGrid(columns: [GridItem(.flexible(), spacing: 15), GridItem(.flexible())], spacing: 15) {
                        ForEach(0..<hangulUnit.hangulCards.count, id: \.self) { index in
                            let hangulCard = hangulUnit.hangulCards[index]
                            ConsonantChapterContentView(hangulCard: hangulCard)
                        }
                    }
```

 ## 작업 결과(이미지 첨부는 선택)
<img width="1352" alt="스크린샷 2023-10-23 오전 12 14 13" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team3-BluePeriodClub/assets/83645833/57dd675b-6d12-4e25-a3a7-a8d7143fcbd4">


