### PR TITLE
[Feat/#35] 교육 중 화면 전환 연결 하기

### DIFF
--- a/Orum/Orum/OrumApp.swift
+++ b/Orum/Orum/OrumApp.swift
@@ -12,29 +12,30 @@ struct OrumApp: App {
     @StateObject private var navigationManager = NavigationManager()
     var body: some Scene {
         WindowGroup {
-//            switch navigationManager.viewCycle {
-//            case .first:
-//                TripDateSettingView()
-//                    .environmentObject(navigationManager)
-//            case .second:
-//                TripRemainingDayView()
-//                    .environmentObject(navigationManager)
-//            case .third:
-//                FlightInfoSubmitView()
-//                    .environmentObject(navigationManager)
-//            case .fourth:
-//                DepartRemainingTimeView()
-//                    .environmentObject(navigationManager)
-//            case .fifth:
-//                HangulEducationMainView()
-//                    .environmentObject(navigationManager)
-//            }
-            ConsonantCardView(hangulUnit: HangulUnit(unitName: "consonants1", unitIndex: 0, hangulCards: [
-                HangulCard(name: "ㄱ", sound: "g", example1: "가", example2: "구", soundExample1: "ga", soundExample2: "gu", quiz: "가든", lottieName: "gun"),
-                HangulCard(name: "ㄴ", sound: "n", example1: "나", example2: "누", soundExample1: "na", soundExample2: "nu", quiz: "나노", lottieName: "nose"),
-                HangulCard(name: "ㄷ", sound: "d", example1: "다", example2: "두", soundExample1: "da", soundExample2: "du", quiz: "다트", lottieName: "drink"),
-                HangulCard(name: "ㄹ", sound: "r", example1: "라", example2: "루", soundExample1: "ra", soundExample2: "ru", quiz: "라디오", lottieName: "road")
-            ]))
+            switch navigationManager.viewCycle {
+            case .first:
+                TripDateSettingView()
+                    .environmentObject(navigationManager)
+            case .second:
+                TripRemainingDayView()
+                    .environmentObject(navigationManager)
+            case .third:
+                FlightInfoSubmitView()
+                    .environmentObject(navigationManager)
+            case .fourth:
+                DepartRemainingTimeView()
+                    .environmentObject(navigationManager)
+            case .fifth:
+                HangulEducationMainView()
+                    .environmentObject(navigationManager)
+            }
+            
+//            ConsonantCardView(hangulUnit: HangulUnit(unitName: "consonants1", unitIndex: 0, hangulCards: [
+//                HangulCard(name: "ㄱ", sound: "g", example1: "가", example2: "구", soundExample1: "ga", soundExample2: "gu", quiz: "가든", lottieName: "gun"),
+//                HangulCard(name: "ㄴ", sound: "n", example1: "나", example2: "누", soundExample1: "na", soundExample2: "nu", quiz: "나노", lottieName: "nose"),
+//                HangulCard(name: "ㄷ", sound: "d", example1: "다", example2: "두", soundExample1: "da", soundExample2: "du", quiz: "다트", lottieName: "drink"),
+//                HangulCard(name: "ㄹ", sound: "r", example1: "라", example2: "루", soundExample1: "ra", soundExample2: "ru", quiz: "라디오", lottieName: "road")
+//            ]))
         }
     }
 }

--- a/Orum/Orum/Views/ConsonantCardView.swift
+++ b/Orum/Orum/Views/ConsonantCardView.swift
@@ -8,7 +8,10 @@
 import SwiftUI
 
 struct ConsonantCardView: View {
+    @AppStorage("arr_time") var arr_time: Date = Date()
     
+    @EnvironmentObject var educationManager: EducationManager
+
     @State var hangulUnit : HangulUnit
     @State var flipCheck : Bool = false
     @State var example1Check : Bool = false
@@ -17,9 +20,13 @@ struct ConsonantCardView: View {
     @State var nextWordActive: Bool = false
     @State var flipped: Bool = false
     @State var chapterViewActive: Bool = false
+    @State var remainingSeconds: Int = 3600
+    @State var isCountdownOver: Bool = false
     
+    var timer = Timer.publish(every: 1, on: .main, in: .common).autoconnect()
     
     var body: some View {
+        
         NavigationStack{
             ZStack{
                 Color(uiColor: UIColor(hex: "F2F2F7")).edgesIgnoringSafeArea(/*@START_MENU_TOKEN@*/.all/*@END_MENU_TOKEN@*/)
@@ -95,11 +102,18 @@ struct ConsonantCardView: View {
                 }
                 .frame(width: UIScreen.main.bounds.size.width - 30)
             }
+            .onAppear {
+                remainingSeconds = Int(arr_time.timeIntervalSince(Date()))
+            }
+            .onDisappear {
+                timer.upstream.connect().cancel()
+            }
             .navigationTitle(hangulUnit.unitName.capitalized)
             .navigationBarTitleDisplayMode(.large)
             .navigationDestination(isPresented: $chapterViewActive, destination: {
                 ConsonantChapterView(hangulUnit:  HangulUnit(unitName: hangulUnit.unitName, unitIndex: hangulUnit.unitIndex + 1, hangulCards: hangulUnit.hangulCards)
 )
+                .environmentObject(educationManager)
             })
             .navigationBarBackButtonHidden()
             .transition(.slide)
@@ -113,8 +127,10 @@ struct ConsonantCardView: View {
             checkCount = 0
             example2Check = false
             flipped = false
+            print("###", educationManager)
         }
     }
+    
     func previousWord() {
         withAnimation(.easeInOut(duration: 1)){
             hangulUnit = HangulUnit(unitName: hangulUnit.unitName, unitIndex: hangulUnit.unitIndex - 1, hangulCards: hangulUnit.hangulCards)
@@ -124,6 +140,14 @@ struct ConsonantCardView: View {
             example2Check = false
             flipped = false
         }
+    }
+    
+    func timeString(_ seconds: Int) -> String {
+        var minutes = seconds / 60
+        let hours = minutes / 60
+        minutes = minutes % 60
+        let seconds = seconds % 60
+        return String(format: "%02d:%02d:%02d",hours, minutes, seconds)
     }
 }
 

--- a/Orum/Orum/Views/ConsonantChapterView.swift
+++ b/Orum/Orum/Views/ConsonantChapterView.swift
@@ -8,7 +8,7 @@
 import SwiftUI
 
 struct ConsonantChapterView: View {
-    
+    @EnvironmentObject var educationManager: EducationManager
     @State var hangulUnit : HangulUnit
     @State var quizViewActive: Bool = false
 
@@ -72,6 +72,7 @@ struct ConsonantChapterView: View {
             .navigationDestination(isPresented: $quizViewActive, destination: {
                 ConsonantQuizView(hangulUnit:  HangulUnit(unitName: hangulUnit.unitName, unitIndex: 0, hangulCards: hangulUnit.hangulCards)
 )
+                .environmentObject(educationManager)
             })
         }
     }

--- a/Orum/Orum/Views/ConsonantQuizView.swift
+++ b/Orum/Orum/Views/ConsonantQuizView.swift
@@ -8,12 +8,14 @@
 import SwiftUI
 
 struct ConsonantQuizView: View {
-    
+    @EnvironmentObject var educationManager: EducationManager
+
     @State var hangulUnit : HangulUnit
     @State var isOptionClicked : Bool = false
     @State var clickedOptionIndex : Int = 5
     @State var answerIndex : Int = 5
     @State var isSubmitAnswer : Bool = false
+    @State var isFinishButtonPressed: Bool = false
     @State var optionAlphabet : [Character] = []
     
     
@@ -98,7 +100,6 @@ struct ConsonantQuizView: View {
                             if String(optionAlphabet[index]) == hangulUnit.hangulCards[hangulUnit.unitIndex].sound {
                                 answerIndex = index
                             }
-                            print("###Hi")
                         }
                         .onChange(of: isSubmitAnswer) { _ in
                             if String(optionAlphabet[index]) == hangulUnit.hangulCards[hangulUnit.unitIndex].sound {
@@ -151,10 +152,13 @@ struct ConsonantQuizView: View {
                         .clipShape(RoundedRectangle(cornerRadius: 12.0))
 //                        .shadow(radius: 3)
                         .onTapGesture {
-//                            if hangulUnit.unitIndex == hangulUnit.hangulCards.count{
-//                                
-//                            }
+                            if hangulUnit.unitIndex == hangulUnit.hangulCards.count - 1{
+                                isFinishButtonPressed.toggle()
+                                educationManager.unit = .Consonants2
+                                isSubmitAnswer = false
+                            }
                             if isSubmitAnswer {
+                                print("if 문 진입")
                                 nextQuiz()
                                 optionAlphabet = quizAlgorithm()
                             } else{
@@ -168,9 +172,17 @@ struct ConsonantQuizView: View {
             }
             .navigationTitle(String(localized: "Quiz"))
             .navigationBarBackButtonHidden()
+            .navigationDestination(isPresented: $isFinishButtonPressed, destination: {
+                HangulEducationTableView()
+                    .navigationBarBackButtonHidden()
+                    .environmentObject(educationManager)
+            })
             .onAppear {
-                optionAlphabet = quizAlgorithm()
-                print("Hi")
+                if hangulUnit.unitIndex != hangulUnit.hangulCards.count {
+                    print("###179")
+                    optionAlphabet = quizAlgorithm()
+                }
+                print("###181")
             }
         }
     }

--- a/Orum/Orum/Views/HangulEducationTableView.swift
+++ b/Orum/Orum/Views/HangulEducationTableView.swift
@@ -117,13 +117,89 @@ struct HangulEducationTableView: View {
                                 .padding(.horizontal, 15)
                                 
                                 HStack {
+                                    if educationManager.unit.rawValue == "Consonants 1" {
                                     ForEach (0 ..< 4) { _ in
+                                            RoundedRectangle(cornerRadius: 4)
+                                                .foregroundColor(.accentColor)
+                                                .frame(width: 50 ,height: 70)
+                                        }
+                                    }
+                                    else {
                                         RoundedRectangle(cornerRadius: 4)
-                                            .foregroundColor(.accentColor)
-                                            .frame(width: 50 ,height: 70)
+                                            .stroke(.black, lineWidth: 1)
+                                            .frame(width: 50, height: 70)
+                                            .foregroundColor(Color.clear)
+                                            .overlay(
+                                                VStack{
+                                                    Text("ㄱ")
+                                                        .font(.largeTitle)
+                                                        .bold()
+                                                    
+                                                    Text("[g]")
+                                                    
+                                                    Spacer()
+                                                })
+                                        
+                                        RoundedRectangle(cornerRadius: 4)
+                                            .stroke(.black, lineWidth: 1)
+                                            .frame(width: 50, height: 70)
+                                            .foregroundColor(Color.clear)
+                                            .overlay(
+                                                VStack{
+                                                    Text("ㄴ")
+                                                        .font(.largeTitle)
+                                                        .bold()
+                                                    
+                                                    Text("[n]")
+                                                    
+                                                    Spacer()
+                                                })
+                                        
+                                        RoundedRectangle(cornerRadius: 4)
+                                            .stroke(.black, lineWidth: 1)
+                                            .frame(width: 50, height: 70)
+                                            .foregroundColor(Color.clear)
+                                            .overlay(
+                                                VStack{
+                                                    Text("ㄷ")
+                                                        .font(.largeTitle)
+                                                        .bold()
+                                                    
+                                                    Text("[d]")
+                                                    
+                                                    Spacer()
+                                                })
+                                        
+                                        RoundedRectangle(cornerRadius: 4)
+                                            .stroke(.black, lineWidth: 1)
+                                            .frame(width: 50, height: 70)
+                                            .foregroundColor(Color.clear)
+                                            .overlay(
+                                                VStack{
+                                                    Text("ㄹ")
+                                                        .font(.largeTitle)
+                                                        .bold()
+                                                    
+                                                    Text("[r]")
+                                                    
+                                                    Spacer()
+                                                })
+                            
                                     }
                                 }
                                 .padding(.horizontal, 20)
+                                
+                                HStack {
+                                    ForEach (0 ..< 5) { _ in
+                                        if educationManager.unit.rawValue == "Consonants 2" {
+                                            RoundedRectangle(cornerRadius: 4)
+                                                .foregroundColor(.accentColor)
+                                                .frame(width: 50 ,height: 70)
+                                        }
+                                    }
+                                }
+                                .padding(.horizontal, 20)
+
                                 
                                 Divider()
                                 


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->
- 한 단원 학습을 마치고 다시 테이블뷰로 돌아가는 화면 전환 구조를 구현하였습니다.
-작업 이슈 : #35. 

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->
- 화면 전환 구조 구현하기

## Logic
<!-- 작업 내용 1 -->
```swift

```
각각 화면이 전환 될 때, educationManager 을 전달해줘서 educationManager를 업데이트 해주고 이를 통해 화면을 전환합니다.

 ## 작업 결과(이미지 첨부는 선택)
![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team3-BluePeriodClub/assets/58865827/0afcff6f-a85b-40dc-a6c5-04840aee4379)
