### PR TITLE
[Fix/#44] ConsonantQuizView 의 오류를 수정하였습니다

### DIFF
--- a/Orum/Orum/Views/ConsonantCardView.swift
+++ b/Orum/Orum/Views/ConsonantCardView.swift
@@ -116,7 +116,7 @@ struct ConsonantCardView: View {
                 .environmentObject(educationManager)
             })
             .navigationBarBackButtonHidden()
-            .transition(.slide)
+//            .transition(.opacity)
         }
     }
     func nextWord() {
@@ -157,5 +157,5 @@ struct ConsonantCardView: View {
         HangulCard(name: "ㄴ", sound: "n", example1: "나", example2: "누", soundExample1: "na", soundExample2: "nu", quiz: "나노", lottieName: "nose"),
         HangulCard(name: "ㄷ", sound: "d", example1: "다", example2: "두", soundExample1: "da", soundExample2: "du", quiz: "다트", lottieName: "drink"),
         HangulCard(name: "ㄹ", sound: "r", example1: "라", example2: "루", soundExample1: "ra", soundExample2: "ru", quiz: "라디오", lottieName: "road")
-    ]))
+    ])).environmentObject(EducationManager())
 }

--- a/Orum/Orum/Views/ConsonantQuizView.swift
+++ b/Orum/Orum/Views/ConsonantQuizView.swift
@@ -22,7 +22,7 @@ struct ConsonantQuizView: View {
     var body: some View {
         NavigationStack{
             ZStack{
-                Color(uiColor: UIColor(hex: "F2F2F7")).edgesIgnoringSafeArea(.all)
+                Color(uiColor: .secondarySystemBackground).edgesIgnoringSafeArea(.all)
                 VStack{
                     ZStack{
                         VStack{
@@ -31,7 +31,8 @@ struct ConsonantQuizView: View {
                                 Text("\(hangulUnit.unitIndex + 1)/\(hangulUnit.hangulCards.count)")
                                     .fontWeight(.bold)
                                     .font(.body)
-                                    .foregroundStyle(Color(UIColor(hex: "D1D1D6")))
+                                    .foregroundColor(Color(uiColor: .systemGray4))
+                                    
                             }
                             ZStack(alignment: .leading){
                                 Text(hangulUnit.hangulCards[hangulUnit.unitIndex].quiz.prefix(1))
@@ -39,26 +40,26 @@ struct ConsonantQuizView: View {
                                     .font(.system(size: 105))
                                     .padding(.bottom, 10)
                                     .foregroundColor(.clear)
-                                    .underline(true, color: .black)
+                                    .underline(true, color: Color(uiColor: .label))
                                     .offset(y: 10)
                                 Text(hangulUnit.hangulCards[hangulUnit.unitIndex].quiz)
                                     .fontWeight(.bold)
                                     .font(.system(size: 105))
+                                    .foregroundColor(Color(uiColor: .label))
                                     .padding(.bottom, 10)
                             }
                             let qandaStatus = fetchQandaStatus()
                             Text(qandaStatus.text)
                                 .fontWeight(.bold)
                                 .font(.body)
-                                .foregroundStyle(qandaStatus.color)
+                                .foregroundColor(qandaStatus.color)
                         }
                         .padding(EdgeInsets(top: 10, leading: 10, bottom: 20, trailing: 10))
                     }
-                    .background(Color.white)
+                    .background(Color(uiColor: .systemBackground))
                     .clipShape(RoundedRectangle(cornerRadius: 15.0))
                     ForEach(0..<optionAlphabet.count, id: \.self) { index in
-                        let status = optionStatus(index: index)
-                        let optionColor = fetchOptionColor(status: status)
+                        let optionColor = fetchOptionColor(index: index)
                         ZStack{
                             HStack(spacing: 20){
                                 Circle()
@@ -67,22 +68,22 @@ struct ConsonantQuizView: View {
                                     .overlay {
                                         Circle()
                                             .frame(width: 20, height: 20)
-                                            .foregroundStyle(optionColor.circle)
+                                            .foregroundColor(optionColor.circle)
                                     }
                                 ZStack{
                                     Text("\(String(optionAlphabet[index]))")
                                         .fontWeight(.bold)
                                         .font(.title2)
-                                        .foregroundStyle(optionColor.text)
+                                        .foregroundColor(optionColor.text)
                                     +
                                     Text("a")
                                         .fontWeight(.bold)
                                         .font(.title2)
-                                        .foregroundStyle(optionColor.text)
+                                        .foregroundColor(optionColor.text)
                                 Text("[      ]")
                                     .fontWeight(.bold)
                                     .font(.title2)
-                                    .foregroundStyle(optionColor.bracket)
+                                    .foregroundColor(optionColor.bracket)
                                 }
                                 Spacer()
                             }
@@ -94,7 +95,9 @@ struct ConsonantQuizView: View {
                             .stroke(optionColor.border, lineWidth: 3))
                         .padding(EdgeInsets(top: 5, leading: 10, bottom: 0, trailing: 10))
                         .onTapGesture {
-                            clickedOptionIndex = index
+                            if !isSubmitAnswer {
+                                clickedOptionIndex = index
+                            }
                         }
                         .onAppear {
                             if String(optionAlphabet[index]) == hangulUnit.hangulCards[hangulUnit.unitIndex].sound {
@@ -113,21 +116,21 @@ struct ConsonantQuizView: View {
                     HStack{
                         ZStack{
                             Image(systemName: "arrow.uturn.backward")
-                                .foregroundStyle(.blue)
+                                .foregroundColor(.blue)
                                 .font(.system(size: 32.0))
                                 .padding(10)
                         }
-                        .background(Color.white)
+                        .background(Color(uiColor: .systemBackground))
                         .clipShape(RoundedRectangle(cornerRadius: 15.0))
-//                        .shadow(radius: 3)
                         .onTapGesture {
                             print()
                         }
                         Spacer()
                         
                         ZStack{
+                            // 버튼 크기 맞추기 위한 코드
                             Image(systemName: "arrow.uturn.backward")
-                                .foregroundStyle(.clear)
+                                .foregroundColor(.clear)
                                 .font(.system(size: 32.0))
                                 .padding(10)
                             HStack{
@@ -135,22 +138,21 @@ struct ConsonantQuizView: View {
                                     Text(String(localized: "Continue"))
                                         .fontWeight(.bold)
                                         .font(.system(size: 20))
-                                        .foregroundStyle(.white)
+                                        .foregroundColor(.white)
                                 } else {
                                     Image(systemName: "arrow.right.circle.fill")
                                         .font(.system(size: 32.0))
-                                        .foregroundStyle(.white)
+                                        .foregroundColor(.white)
                                     Text(String(localized: "Next"))
                                         .fontWeight(.bold)
                                         .font(.system(size: 17))
-                                        .foregroundStyle(.white)
+                                        .foregroundColor(.white)
                                 }
                             }
                             .padding(EdgeInsets(top: 10, leading: 20, bottom: 10, trailing: 20))
                         }
                         .background(.blue)
                         .clipShape(RoundedRectangle(cornerRadius: 12.0))
-//                        .shadow(radius: 3)
                         .onTapGesture {
                             if hangulUnit.unitIndex == hangulUnit.hangulCards.count - 1{
                                 isFinishButtonPressed.toggle()
@@ -158,7 +160,6 @@ struct ConsonantQuizView: View {
                                 isSubmitAnswer = false
                             }
                             if isSubmitAnswer {
-                                print("if 문 진입")
                                 nextQuiz()
                                 optionAlphabet = quizAlgorithm()
                             } else{
@@ -180,10 +181,8 @@ struct ConsonantQuizView: View {
             })
             .onAppear {
                 if hangulUnit.unitIndex != hangulUnit.hangulCards.count {
-                    print("###179")
                     optionAlphabet = quizAlgorithm()
                 }
-                print("###181")
             }
         }
     }
@@ -195,33 +194,17 @@ struct ConsonantQuizView: View {
         return optionAlphabet.shuffled()
     }
     
-    func optionStatus(index: Int) -> Int {
+    func fetchOptionColor(index: Int) -> OptionColor {
         if index != clickedOptionIndex && !isSubmitAnswer {
-            return 1
+            return OptionColor(circle: .clear, text: Color(uiColor: .label), bracket: Color(uiColor: .label).opacity(0.4), background: Color(uiColor: .systemBackground), border: .clear)
         } else if index == clickedOptionIndex && !isSubmitAnswer {
-            return 2
+            return OptionColor(circle: .blue, text: .blue, bracket: .blue.opacity(0.4), background: Color(uiColor: .systemBackground), border: .blue)
         } else if index != answerIndex && isSubmitAnswer && index == clickedOptionIndex {
-            return 3
+            return OptionColor(circle: .red, text: .red, bracket: .red.opacity(0.4), background: Color(uiColor: .systemBackground), border: .red)
         } else if index == answerIndex && isSubmitAnswer {
-            return 4
+            return OptionColor(circle: .white, text: .white, bracket: .white.opacity(0.4), background: .blue, border: .clear)
         }
-        return 1
-    }
-    
-    func fetchOptionColor(status: Int) -> OptionColor {
-        switch status {
-        case 1 :
-            return OptionColor(circle: .clear, text: .black, bracket: .gray, background: .white, border: .clear)
-        case 2 :
-            return OptionColor(circle: .blue, text: .blue, bracket: .blue, background: .white, border: .blue)
-        case 3 :
-            return OptionColor(circle: .red, text: .red, bracket: .red, background: .white, border: .red)
-        case 4 :
-            return OptionColor(circle: .white, text: .white, bracket: .white, background: .blue, border: .clear)
-        default:
-            return OptionColor(circle: .clear, text: .black, bracket: .gray, background: .white, border: .clear)
-        }
-        
+        return OptionColor(circle: .clear, text: Color(uiColor: .label), bracket: Color(uiColor: .label).opacity(0.4), background: Color(uiColor: .systemBackground), border: .clear)
     }
     
     func fetchQandaStatus() -> QandA {
@@ -265,5 +248,13 @@ struct QandA {
         HangulCard(name: "ㄴ", sound: "n", example1: "나", example2: "누", soundExample1: "na", soundExample2: "nu", quiz: "나노", lottieName: "nose"),
         HangulCard(name: "ㄷ", sound: "d", example1: "다", example2: "두", soundExample1: "da", soundExample2: "du", quiz: "다트", lottieName: "drink"),
         HangulCard(name: "ㄹ", sound: "r", example1: "라", example2: "루", soundExample1: "ra", soundExample2: "ru", quiz: "라디오", lottieName: "road")
-    ]))
+    ])).environmentObject(EducationManager())
+}
+#Preview {
+    ConsonantQuizView(hangulUnit: HangulUnit(unitName: "consonants1", unitIndex: 0, hangulCards: [
+        HangulCard(name: "ㄱ", sound: "g", example1: "가", example2: "구", soundExample1: "ga", soundExample2: "gu", quiz: "가든", lottieName: "gun"),
+        HangulCard(name: "ㄴ", sound: "n", example1: "나", example2: "누", soundExample1: "na", soundExample2: "nu", quiz: "나노", lottieName: "nose"),
+        HangulCard(name: "ㄷ", sound: "d", example1: "다", example2: "두", soundExample1: "da", soundExample2: "du", quiz: "다트", lottieName: "drink"),
+        HangulCard(name: "ㄹ", sound: "r", example1: "라", example2: "루", soundExample1: "ra", soundExample2: "ru", quiz: "라디오", lottieName: "road")
+    ])).environmentObject(EducationManager())
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->
작업 이슈: #44 
ConsonantQuizView 의 오류를 수정하였습니다


## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->

- 정답확인 화면에서도 선택지가 선택되는 문제 수정
- iOS 17 이하에서 대응할 수 있도록 foregroundStyle -> forgroundColor 로 변경
- 다크 모드에 대응 할 수 있도록 시스템 컬러로 변경
- 선택지 경우의수 별로 색깔 변경

## Logic
<!-- 작업 내용 1 -->
```swift
  if !isSubmitAnswer {
                                clickedOptionIndex = index
                            }
```

 ## 작업 결과(이미지 첨부는 선택)
