### PR TITLE
[Feat/#54] HangulEducationView, HangulEducationLearningView 를 구현하였습니다

### DIFF
--- a/Orum/Orum.xcodeproj/project.pbxproj
+++ b/Orum/Orum.xcodeproj/project.pbxproj
@@ -21,12 +21,15 @@
 		937620392AF0808700DE2C50 /* GameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 937620382AF0808700DE2C50 /* GameView.swift */; };
 		9376203B2AF0808F00DE2C50 /* SearchView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9376203A2AF0808F00DE2C50 /* SearchView.swift */; };
 		9376203D2AF080B500DE2C50 /* HangulEducationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9376203C2AF080B500DE2C50 /* HangulEducationView.swift */; };
-		9376203F2AF080F200DE2C50 /* FlightManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9376203E2AF080F200DE2C50 /* FlightManager.swift */; };
 		93F58B632AE623570022B59B /* HangulEducationTableView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F58B622AE623570022B59B /* HangulEducationTableView.swift */; };
-		93F68C7A2AE0492E00B96F5C /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F68C792AE0492E00B96F5C /* NavigationManager.swift */; };
 		93F68C7C2AE04B6600B96F5C /* DepartRemainingTimeView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F68C7B2AE04B6600B96F5C /* DepartRemainingTimeView.swift */; };
 		93FED9482AE4F64F0004A0F5 /* HangulEducationMainView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FED9472AE4F64F0004A0F5 /* HangulEducationMainView.swift */; };
-		93FED94C2AE505820004A0F5 /* EducationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93FED94B2AE505820004A0F5 /* EducationManager.swift */; };
+		D9037CDF2AF093360098DB57 /* NavigationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9037CDE2AF093360098DB57 /* NavigationManager.swift */; };
+		D9037CE12AF093540098DB57 /* FlightManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9037CE02AF093540098DB57 /* FlightManager.swift */; };
+		D9037CE52AF093780098DB57 /* EducationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9037CE42AF093780098DB57 /* EducationManager.swift */; };
+		D9037CE72AF0C4270098DB57 /* HangulEducationLearningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9037CE62AF0C4260098DB57 /* HangulEducationLearningView.swift */; };
+		D9037CE92AF0C55A0098DB57 /* HangulEducationQuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9037CE82AF0C55A0098DB57 /* HangulEducationQuizView.swift */; };
+		D9037D092AF0D2B70098DB57 /* HangulCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9037D082AF0D2B70098DB57 /* HangulCardView.swift */; };
 		D927C6C32AE5A10C000CB0C4 /* ConsonantQuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D927C6C22AE5A10C000CB0C4 /* ConsonantQuizView.swift */; };
 		D950CF612AE125AF00BD9EB3 /* FlightInfoEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D950CF602AE125AF00BD9EB3 /* FlightInfoEditView.swift */; };
 		D950CF632AE1277600BD9EB3 /* FlightCodeAPIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D950CF622AE1277600BD9EB3 /* FlightCodeAPIManager.swift */; };
@@ -75,13 +78,16 @@
 		937620382AF0808700DE2C50 /* GameView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GameView.swift; sourceTree = "<group>"; };
 		9376203A2AF0808F00DE2C50 /* SearchView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchView.swift; sourceTree = "<group>"; };
 		9376203C2AF080B500DE2C50 /* HangulEducationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulEducationView.swift; sourceTree = "<group>"; };
-		9376203E2AF080F200DE2C50 /* FlightManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightManager.swift; sourceTree = "<group>"; };
 		93D0BDA52AE2B54E00455447 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		93F58B622AE623570022B59B /* HangulEducationTableView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulEducationTableView.swift; sourceTree = "<group>"; };
-		93F68C792AE0492E00B96F5C /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
 		93F68C7B2AE04B6600B96F5C /* DepartRemainingTimeView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DepartRemainingTimeView.swift; sourceTree = "<group>"; };
 		93FED9472AE4F64F0004A0F5 /* HangulEducationMainView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulEducationMainView.swift; sourceTree = "<group>"; };
-		93FED94B2AE505820004A0F5 /* EducationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EducationManager.swift; sourceTree = "<group>"; };
+		D9037CDE2AF093360098DB57 /* NavigationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationManager.swift; sourceTree = "<group>"; };
+		D9037CE02AF093540098DB57 /* FlightManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightManager.swift; sourceTree = "<group>"; };
+		D9037CE42AF093780098DB57 /* EducationManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EducationManager.swift; sourceTree = "<group>"; };
+		D9037CE62AF0C4260098DB57 /* HangulEducationLearningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulEducationLearningView.swift; sourceTree = "<group>"; };
+		D9037CE82AF0C55A0098DB57 /* HangulEducationQuizView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulEducationQuizView.swift; sourceTree = "<group>"; };
+		D9037D082AF0D2B70098DB57 /* HangulCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulCardView.swift; sourceTree = "<group>"; };
 		D927C6C22AE5A10C000CB0C4 /* ConsonantQuizView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsonantQuizView.swift; sourceTree = "<group>"; };
 		D950CF602AE125AF00BD9EB3 /* FlightInfoEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightInfoEditView.swift; sourceTree = "<group>"; };
 		D950CF622AE1277600BD9EB3 /* FlightCodeAPIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightCodeAPIManager.swift; sourceTree = "<group>"; };
@@ -181,13 +187,10 @@
 		930F26D82ADD0DCC00896A32 /* Models */ = {
 			isa = PBXGroup;
 			children = (
-				93F68C792AE0492E00B96F5C /* NavigationManager.swift */,
 				D950CF642AE127C600BD9EB3 /* FlightCodeAPIData.swift */,
 				D950CF662AE1283B00BD9EB3 /* FlightInfo.swift */,
 				D967D1BC2AE2932C008B3379 /* HangulCard.swift */,
 				D967D1C02AE2A968008B3379 /* HangulUnit.swift */,
-				93FED94B2AE505820004A0F5 /* EducationManager.swift */,
-				9376203E2AF080F200DE2C50 /* FlightManager.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -209,6 +212,9 @@
 				D950CF622AE1277600BD9EB3 /* FlightCodeAPIManager.swift */,
 				D967D1C82AE40F4E008B3379 /* TTSManager.swift */,
 				D96D94472AE778680077F2C1 /* SoundManager.swift */,
+				D9037CDE2AF093360098DB57 /* NavigationManager.swift */,
+				D9037CE02AF093540098DB57 /* FlightManager.swift */,
+				D9037CE42AF093780098DB57 /* EducationManager.swift */,
 			);
 			path = ViewModels;
 			sourceTree = "<group>";
@@ -235,6 +241,9 @@
 				937620382AF0808700DE2C50 /* GameView.swift */,
 				9376203A2AF0808F00DE2C50 /* SearchView.swift */,
 				9376203C2AF080B500DE2C50 /* HangulEducationView.swift */,
+				D9037CE62AF0C4260098DB57 /* HangulEducationLearningView.swift */,
+				D9037D082AF0D2B70098DB57 /* HangulCardView.swift */,
+				D9037CE82AF0C55A0098DB57 /* HangulEducationQuizView.swift */,
 			);
 			path = "ver 1.1";
 			sourceTree = "<group>";
@@ -384,12 +393,14 @@
 				D927C6C32AE5A10C000CB0C4 /* ConsonantQuizView.swift in Sources */,
 				937620392AF0808700DE2C50 /* GameView.swift in Sources */,
 				93F58B632AE623570022B59B /* HangulEducationTableView.swift in Sources */,
-				93F68C7A2AE0492E00B96F5C /* NavigationManager.swift in Sources */,
 				933A8E522ADD1B2E002AE727 /* FlightInfoSubmitView.swift in Sources */,
 				D967D1C32AE2BD83008B3379 /* ConsonantCardView.swift in Sources */,
+				D9037CE92AF0C55A0098DB57 /* HangulEducationQuizView.swift in Sources */,
 				93FED9482AE4F64F0004A0F5 /* HangulEducationMainView.swift in Sources */,
 				9376203D2AF080B500DE2C50 /* HangulEducationView.swift in Sources */,
 				937620342AF0805A00DE2C50 /* FlightMainView.swift in Sources */,
+				D9037CE52AF093780098DB57 /* EducationManager.swift in Sources */,
+				D9037CDF2AF093360098DB57 /* NavigationManager.swift in Sources */,
 				93F68C7C2AE04B6600B96F5C /* DepartRemainingTimeView.swift in Sources */,
 				D950CF672AE1283B00BD9EB3 /* FlightInfo.swift in Sources */,
 				D950CF632AE1277600BD9EB3 /* FlightCodeAPIManager.swift in Sources */,
@@ -398,8 +409,8 @@
 				D95E209C2AE54D1F0062F3EB /* ConsonantChapterContentView.swift in Sources */,
 				D96BAC6A2AE6C37800613540 /* LottieVIew.swift in Sources */,
 				933A8E4A2ADD1A53002AE727 /* Date+RawValue.swift in Sources */,
-				93FED94C2AE505820004A0F5 /* EducationManager.swift in Sources */,
 				D967D1BD2AE2932C008B3379 /* HangulCard.swift in Sources */,
+				D9037D092AF0D2B70098DB57 /* HangulCardView.swift in Sources */,
 				93576C302AEF5E9100CCB3B3 /* Extension+ToDate.swift in Sources */,
 				D950CF612AE125AF00BD9EB3 /* FlightInfoEditView.swift in Sources */,
 				933A8E502ADD1AF6002AE727 /* TripRemainingDayView.swift in Sources */,
@@ -410,7 +421,8 @@
 				930F26C92ADD0D8B00896A32 /* OrumApp.swift in Sources */,
 				933A8E4C2ADD1A84002AE727 /* Calendar+CompareDays.swift in Sources */,
 				D96D94482AE778680077F2C1 /* SoundManager.swift in Sources */,
-				9376203F2AF080F200DE2C50 /* FlightManager.swift in Sources */,
+				D9037CE72AF0C4270098DB57 /* HangulEducationLearningView.swift in Sources */,
+				D9037CE12AF093540098DB57 /* FlightManager.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/Orum/Orum/Models/HangulUnit.swift
+++ b/Orum/Orum/Models/HangulUnit.swift
@@ -9,6 +9,6 @@ import Foundation
 
 struct HangulUnit {
     let unitName : String
-    let unitIndex : Int
+    var unitIndex : Int
     let hangulCards : [HangulCard]
 }

--- a/Orum/Orum/ViewModels/EducationManager.swift
+++ b/Orum/Orum/ViewModels/EducationManager.swift
@@ -19,7 +19,7 @@ class EducationManager: ObservableObject {
     init() {
         educationProgress = 0
         chapter = .consonant1
-        content = HangulUnit(unitName: "", unitIndex: 1, hangulCards: [])
+        content = HangulUnit(unitName: "", unitIndex: 0, hangulCards: [HangulCard(name: "ㄱ", sound: "g", example1: "가", example2: "구", soundExample1: "ga", soundExample2: "gu", quiz: "가든", lottieName: "gun"),HangulCard(name: "ㄴ", sound: "n", example1: "나", example2: "누", soundExample1: "na", soundExample2: "nu", quiz: "나노", lottieName: "nose"),HangulCard(name: "ㄷ", sound: "d", example1: "다", example2: "두", soundExample1: "da", soundExample2: "du", quiz: "다트", lottieName: "drink"),HangulCard(name: "ㄹ", sound: "r", example1: "라", example2: "루", soundExample1: "ra", soundExample2: "ru", quiz: "라디오", lottieName: "road")])
     }
     
     func createContent() {

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/HangulCardView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/HangulCardView.swift
@@ -1,0 +1,98 @@
+//
+//  HangulCardView.swift
+//  Orum
+//
+//  Created by Youngbin Choi on 10/31/23.
+//
+
+import SwiftUI
+
+struct HangulCardView: View {
+    
+    @Binding var content : HangulUnit
+    @Binding var flipCheck : Bool
+    @Binding var flipped: Bool
+    
+    var body: some View {
+        ZStack{
+            VStack(spacing: 16){
+                if !flipped {
+                    Image(content.hangulCards[content.unitIndex].name)
+                        .resizable()
+                        .frame(width: 180, height: 180)
+                    ZStack{
+                        Text(content.hangulCards[content.unitIndex].sound)
+                            .fontWeight(.bold)
+                            .font(.largeTitle)
+                        Text("[   ]")
+                            .fontWeight(.bold)
+                            .font(.largeTitle)
+                            .foregroundStyle(Color(UIColor(hex: "D1D1D6")))
+                    }
+                } else {
+                    LottieView(fileName: content.hangulCards[content.unitIndex].name)
+                        .frame(width: 180, height: 180)
+                        .scaleEffect(x: -1, y: 1)
+                    ZStack{
+                        Text("[")
+                            .fontWeight(.bold)
+                            .font(.largeTitle)
+                            .foregroundStyle(Color(UIColor(hex: "D1D1D6")))
+                        +
+                        Text(content.hangulCards[content.unitIndex].lottieName)
+                            .fontWeight(.bold)
+                            .font(.largeTitle)
+                        +
+                        Text("]")
+                            .fontWeight(.bold)
+                            .font(.largeTitle)
+                            .foregroundStyle(Color(UIColor(hex: "D1D1D6")))
+                    }
+                    .scaleEffect(x: -1, y: 1)
+                }
+//                Divider()
+//                Image(systemName: "lightbulb.circle.fill")
+//                    .font(.system(size: 32.0))
+//                    .foregroundStyle(.blue)
+//                    .padding(10)
+//                    .onTapGesture {
+//                        if !flipCheck {
+//                            checkCount += 1
+//                        }
+//                        flipped.toggle()
+//                        flipCheck = true
+//                    }
+//                    .overlay {
+//                        Circle()
+//                            .frame(width: 4)
+//                            .offset(y: 20)
+//                            .foregroundStyle( flipCheck ? .blue : .clear )
+//                    }
+            }
+            .padding(EdgeInsets(top: 50, leading: 30, bottom: 40, trailing: 30))
+        }
+        .background(Color.white)
+        .clipShape(RoundedRectangle(cornerRadius: 10.0))
+        .overlay(RoundedRectangle(cornerRadius: 10)
+            .stroke(flipCheck ? Color(uiColor: .systemGray4) : .blue , lineWidth: 11))
+        .rotation3DEffect(flipped ? Angle(degrees: 180) : .zero,
+                          axis: (x: 0.0, y: 1.0, z: 0.0))
+        .animation(.default, value: flipped)
+        .onTapGesture {
+//            if !flipCheck {
+//                checkCount += 1
+//            }
+            flipped.toggle()
+            flipCheck = true
+        }
+    }
+}
+
+#Preview {
+    HangulCardView(content: .constant(HangulUnit(unitName: "consonants1", unitIndex: 0, hangulCards: [
+        HangulCard(name: "ㄱ", sound: "g", example1: "가", example2: "구", soundExample1: "ga", soundExample2: "gu", quiz: "가든", lottieName: "gun"),
+        HangulCard(name: "ㄴ", sound: "n", example1: "나", example2: "누", soundExample1: "na", soundExample2: "nu", quiz: "나노", lottieName: "nose"),
+        HangulCard(name: "ㄷ", sound: "d", example1: "다", example2: "두", soundExample1: "da", soundExample2: "du", quiz: "다트", lottieName: "drink"),
+        HangulCard(name: "ㄹ", sound: "r", example1: "라", example2: "루", soundExample1: "ra", soundExample2: "ru", quiz: "라디오", lottieName: "road")
+    ])), flipCheck: .constant(false), flipped: .constant(false))
+}

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationLearningView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationLearningView.swift
@@ -1,0 +1,36 @@
+//
+//  HangulEducationLearningView.swift
+//  Orum
+//
+//  Created by Youngbin Choi on 10/31/23.
+//
+
+import SwiftUI
+
+struct HangulEducationLearningView: View {
+    @Binding var content : HangulUnit
+    @Binding var flipCheck : Bool
+    @Binding var flipped: Bool
+    
+    var body: some View {
+        VStack(spacing: 98){
+            HStack{
+                Text("Focus on form and pronunciation")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                Spacer()
+            }
+            
+            HangulCardView(content: $content, flipCheck: $flipCheck, flipped: $flipped)
+        }
+    }
+}
+
+#Preview {
+    HangulEducationLearningView(content: .constant(HangulUnit(unitName: "consonants1", unitIndex: 0, hangulCards: [
+        HangulCard(name: "ㄱ", sound: "g", example1: "가", example2: "구", soundExample1: "ga", soundExample2: "gu", quiz: "가든", lottieName: "gun"),
+        HangulCard(name: "ㄴ", sound: "n", example1: "나", example2: "누", soundExample1: "na", soundExample2: "nu", quiz: "나노", lottieName: "nose"),
+        HangulCard(name: "ㄷ", sound: "d", example1: "다", example2: "두", soundExample1: "da", soundExample2: "du", quiz: "다트", lottieName: "drink"),
+        HangulCard(name: "ㄹ", sound: "r", example1: "라", example2: "루", soundExample1: "ra", soundExample2: "ru", quiz: "라디오", lottieName: "road")
+    ])), flipCheck: .constant(false), flipped: .constant(false))
+}

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationQuizView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationQuizView.swift
@@ -1,0 +1,18 @@
+//
+//  HangulEducationQuizView.swift
+//  Orum
+//
+//  Created by Youngbin Choi on 10/31/23.
+//
+
+import SwiftUI
+
+struct HangulEducationQuizView: View {
+    var body: some View {
+        Text("Quiz")
+    }
+}
+
+#Preview {
+    HangulEducationQuizView()
+}

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationView.swift
@@ -8,27 +8,67 @@
 import SwiftUI
 
 struct HangulEducationView: View {
+    
     @Binding var isPresented: Bool
-    @Binding var content: HangulUnit
+    @State var content: HangulUnit
+    @State var nextpage: Bool = false
+    @State var flipCheck : Bool = false
+    @State var flipped: Bool = false
     
     var body: some View {
-        VStack {
-            HStack {
-                Button(action: {
+        NavigationView {
+            ZStack {
+                VStack(spacing: 0){
+                    VStack{
+                        ProgressView(value: 0.2)
+                            
+                    }
+                    .padding(16)
+                    
+                    Divider()
+                    
+                    HangulEducationLearningView(content: $content, flipCheck: $flipCheck, flipped: $flipped)
+                        .padding(16)
+                    
+                    Spacer()
+                    VStack{
+                        Button(action: {
+                            content.unitIndex += 1
+                            flipCheck = false
+                            flipped = false
+                        }){
+                            HStack{
+                                Spacer()
+                                Text("Got it!")
+                                Spacer()
+                            }
+                            .padding(.vertical, 5)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(!flipCheck ? true : false)
+                        
+                    }
+                    .padding(16)
+                    
+                }
+                .navigationTitle(content.unitName)
+                .navigationBarItems(leading: Button(action: {
                     isPresented.toggle()
                 }) {
-                    Image(systemName: "x.circle.fill")
-                }
-                
-                Spacer()
+                    Image(systemName: "xmark.circle.fill")
+                        .foregroundStyle(.blue, Color(uiColor: .systemGray4))
+                        .symbolRenderingMode(.palette)
+                })
             }
-            .padding(.horizontal, 15)
-            
-            Spacer()
         }
     }
 }
 
 #Preview {
-    HangulEducationView(isPresented: .constant(true), content: .constant(HangulUnit(unitName: "Consonant1", unitIndex: 1, hangulCards: [])))
+    HangulEducationView(isPresented: .constant(true), content: HangulUnit(unitName: "consonants1", unitIndex: 0, hangulCards: [
+        HangulCard(name: "ㄱ", sound: "g", example1: "가", example2: "구", soundExample1: "ga", soundExample2: "gu", quiz: "가든", lottieName: "gun"),
+        HangulCard(name: "ㄴ", sound: "n", example1: "나", example2: "누", soundExample1: "na", soundExample2: "nu", quiz: "나노", lottieName: "nose"),
+        HangulCard(name: "ㄷ", sound: "d", example1: "다", example2: "두", soundExample1: "da", soundExample2: "du", quiz: "다트", lottieName: "drink"),
+        HangulCard(name: "ㄹ", sound: "r", example1: "라", example2: "루", soundExample1: "ra", soundExample2: "ru", quiz: "라디오", lottieName: "road")
+    ]))
 }

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/LearnView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/LearnView.swift
@@ -54,7 +54,8 @@ struct LearnView: View {
             Spacer()
         }
         .fullScreenCover(isPresented: $isPresented, content: {
-            HangulEducationView(isPresented: $isPresented, content: $educationManager.content)
+            HangulEducationView(isPresented: $isPresented, content: educationManager.content)
+                .environmentObject(educationManager)
         })
         
     }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->

HangulEducationView, HangulEducationLearningView 를 구현하였습니다

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->

HangulEducationView
HangulEducationLearningView 
HangulCardView 를 구현하였습니다

## Logic
<!-- 작업 내용 1 -->
```swift
 .fullScreenCover(isPresented: $isPresented, content: {
            HangulEducationView(isPresented: $isPresented, content: educationManager.content)
                .environmentObject(educationManager)
        })
```
```swift
struct HangulEducationView: View {
    
    @Binding var isPresented: Bool
    @State var content: HangulUnit
    @State var nextpage: Bool = false
    @State var flipCheck : Bool = false
    @State var flipped: Bool = false
```

HangulEducationView 에서 content.unit을 바꿔주기 위해, @State 로 사용합니다

 ## 작업 결과(이미지 첨부는 선택)
