### PR TITLE
[Feat/#64] 자음 교육 화면 뷰 구현을 완료하였습니다

### DIFF
--- a/Orum/Orum.xcodeproj/project.pbxproj
+++ b/Orum/Orum.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		D9037CE92AF0C55A0098DB57 /* HangulEducationQuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9037CE82AF0C55A0098DB57 /* HangulEducationQuizView.swift */; };
 		D9037D092AF0D2B70098DB57 /* HangulCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9037D082AF0D2B70098DB57 /* HangulCardView.swift */; };
 		D9037D0B2AF11FD50098DB57 /* HangulEducationRecapView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9037D0A2AF11FD50098DB57 /* HangulEducationRecapView.swift */; };
+		D90B0DFC2AF8697000401C87 /* HangulEducationOnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D90B0DFB2AF8697000401C87 /* HangulEducationOnboardingView.swift */; };
 		D927C6C32AE5A10C000CB0C4 /* ConsonantQuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D927C6C22AE5A10C000CB0C4 /* ConsonantQuizView.swift */; };
 		D950CF612AE125AF00BD9EB3 /* FlightInfoEditView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D950CF602AE125AF00BD9EB3 /* FlightInfoEditView.swift */; };
 		D950CF632AE1277600BD9EB3 /* FlightCodeAPIManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D950CF622AE1277600BD9EB3 /* FlightCodeAPIManager.swift */; };
@@ -100,6 +101,7 @@
 		D9037CE82AF0C55A0098DB57 /* HangulEducationQuizView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulEducationQuizView.swift; sourceTree = "<group>"; };
 		D9037D082AF0D2B70098DB57 /* HangulCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulCardView.swift; sourceTree = "<group>"; };
 		D9037D0A2AF11FD50098DB57 /* HangulEducationRecapView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulEducationRecapView.swift; sourceTree = "<group>"; };
+		D90B0DFB2AF8697000401C87 /* HangulEducationOnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulEducationOnboardingView.swift; sourceTree = "<group>"; };
 		D927C6C22AE5A10C000CB0C4 /* ConsonantQuizView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsonantQuizView.swift; sourceTree = "<group>"; };
 		D950CF602AE125AF00BD9EB3 /* FlightInfoEditView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightInfoEditView.swift; sourceTree = "<group>"; };
 		D950CF622AE1277600BD9EB3 /* FlightCodeAPIManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FlightCodeAPIManager.swift; sourceTree = "<group>"; };
@@ -257,6 +259,7 @@
 				937620382AF0808700DE2C50 /* GameView.swift */,
 				9376203A2AF0808F00DE2C50 /* SearchView.swift */,
 				9376203C2AF080B500DE2C50 /* HangulEducationView.swift */,
+				D90B0DFB2AF8697000401C87 /* HangulEducationOnboardingView.swift */,
 				D9037CE62AF0C4260098DB57 /* HangulEducationLearningView.swift */,
 				D9037D082AF0D2B70098DB57 /* HangulCardView.swift */,
 				D9037CE82AF0C55A0098DB57 /* HangulEducationQuizView.swift */,
@@ -435,6 +438,7 @@
 				93419DD62AF0AD8800DCB322 /* SearchResult.swift in Sources */,
 				93576C302AEF5E9100CCB3B3 /* Extension+ToDate.swift in Sources */,
 				D950CF612AE125AF00BD9EB3 /* FlightInfoEditView.swift in Sources */,
+				D90B0DFC2AF8697000401C87 /* HangulEducationOnboardingView.swift in Sources */,
 				933A8E502ADD1AF6002AE727 /* TripRemainingDayView.swift in Sources */,
 				D967D1C12AE2A968008B3379 /* HangulUnit.swift in Sources */,
 				D950CF652AE127C600BD9EB3 /* FlightCodeAPIData.swift in Sources */,
@@ -591,7 +595,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Orum/Preview Content\"";
-				DEVELOPMENT_TEAM = 834B9VMHHG;
+				DEVELOPMENT_TEAM = 3X7HFG8283;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;
@@ -632,7 +636,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Orum/Preview Content\"";
-				DEVELOPMENT_TEAM = 834B9VMHHG;
+				DEVELOPMENT_TEAM = 3X7HFG8283;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
 				GENERATE_INFOPLIST_FILE = YES;

--- a/Orum/Orum/OrumApp.swift
+++ b/Orum/Orum/OrumApp.swift
@@ -12,33 +12,34 @@ struct OrumApp: App {
     @StateObject private var navigationManager = NavigationManager()
     var body: some Scene {
         WindowGroup {
-            switch navigationManager.viewCycle {
-            case .first:
-                TripDateSettingView()
-                    .environmentObject(navigationManager)
-                    .transition(.slide)
-
-            case .second:
-                TripRemainingDayView()
-                    .environmentObject(navigationManager)
-                    .transition(.slide)
-
-            case .third:
-                FlightInfoSubmitView()
-                    .environmentObject(navigationManager)
-                    .transition(.slide)
-
-            case .fourth:
-                DepartRemainingTimeView()
-                    .environmentObject(navigationManager)
-                    .transition(.slide)
-
-
-//            case .fifth:
-//                HangulEducationMainView()
+//            switch navigationManager.viewCycle {
+//            case .first:
+//                TripDateSettingView()
 //                    .environmentObject(navigationManager)
 //                    .transition(.slide)
-            }
+//
+//            case .second:
+//                TripRemainingDayView()
+//                    .environmentObject(navigationManager)
+//                    .transition(.slide)
+//
+//            case .third:
+//                FlightInfoSubmitView()
+//                    .environmentObject(navigationManager)
+//                    .transition(.slide)
+//
+//            case .fourth:
+//                DepartRemainingTimeView()
+//                    .environmentObject(navigationManager)
+//                    .transition(.slide)
+//
+//
+////            case .fifth:
+////                HangulEducationMainView()
+////                    .environmentObject(navigationManager)
+////                    .transition(.slide)
+//            }
+            FlightMainView()
         }
     }
 }

--- a/Orum/Orum/ViewModels/TTSManager.swift
+++ b/Orum/Orum/ViewModels/TTSManager.swift
@@ -17,7 +17,8 @@ class TTSManager {
     internal func play(_ string: String) {
         let utterance = AVSpeechUtterance(string: string)
         utterance.voice = AVSpeechSynthesisVoice(language: "ko-KR")
-        utterance.rate = 0.4
+        utterance.rate = 0.1
+        utterance.pitchMultiplier = 0.5
         synthesizer.stopSpeaking(at: .immediate)
         synthesizer.speak(utterance)
     }

--- a/Orum/Orum/Views/DuringFlight/ConsonantChapterView.swift
+++ b/Orum/Orum/Views/DuringFlight/ConsonantChapterView.swift
@@ -79,11 +79,11 @@ struct ConsonantChapterView: View {
     }
 }
 
-#Preview {
-    ConsonantChapterView(hangulUnit: HangulUnit(unitName: "consonants1", unitIndex: 0, hangulCards: [
-        HangulCard(name: "ㄱ", sound: "g", example1: "가", example2: "구", soundExample1: "ga", soundExample2: "gu", quiz: "가든", lottieName: "gun"),
-        HangulCard(name: "ㄴ", sound: "n", example1: "나", example2: "누", soundExample1: "na", soundExample2: "nu", quiz: "나노", lottieName: "nose"),
-        HangulCard(name: "ㄷ", sound: "d", example1: "다", example2: "두", soundExample1: "da", soundExample2: "du", quiz: "다트", lottieName: "drink"),
-        HangulCard(name: "ㄹ", sound: "r", example1: "라", example2: "루", soundExample1: "ra", soundExample2: "ru", quiz: "라디오", lottieName: "road")
-    ]))
-}
+//#Preview {
+//    ConsonantChapterView(hangulUnit: HangulUnit(unitName: "consonants1", unitIndex: 0, hangulCards: [
+//        HangulCard(name: "ㄱ", sound: "g", example1: "가", example2: "구", soundExample1: "ga", soundExample2: "gu", quiz: "가든", lottieName: "gun"),
+//        HangulCard(name: "ㄴ", sound: "n", example1: "나", example2: "누", soundExample1: "na", soundExample2: "nu", quiz: "나노", lottieName: "nose"),
+//        HangulCard(name: "ㄷ", sound: "d", example1: "다", example2: "두", soundExample1: "da", soundExample2: "du", quiz: "다트", lottieName: "drink"),
+//        HangulCard(name: "ㄹ", sound: "r", example1: "라", example2: "루", soundExample1: "ra", soundExample2: "ru", quiz: "라디오", lottieName: "road")
+//    ]))
+//}

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/HangulCardView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/HangulCardView.swift
@@ -9,50 +9,61 @@ import SwiftUI
 
 struct HangulCardView: View {
     
+    
     @Binding var content : HangulUnit
+    @Binding var isLearningView : Bool
+    @Binding var touchCardsCount : Int
     @Binding var isOnceFlipped : Bool
     @Binding var isFlipped: Bool
     @State var lottieView : LottieView
     
     var body: some View {
         ZStack{
-            VStack(spacing: 16){
-                if !isFlipped {
-                    Image(content.hangulCards[content.unitIndex].name)
-                        .resizable()
-                        .frame(width: 180, height: 180)
-                    ZStack{
-                        Text(content.hangulCards[content.unitIndex].sound)
-                            .fontWeight(.bold)
-                            .font(.largeTitle)
-                        Text("[   ]")
-                            .fontWeight(.bold)
-                            .font(.largeTitle)
-                            .foregroundColor(Color(uiColor: .systemGray4))
-                    }
-                } else {
-                    LottieView(fileName: content.hangulCards[content.unitIndex].name)
-                        .frame(width: 180, height: 180)
+            HStack{
+                Spacer()
+                VStack(spacing: 16){
+                    if !isFlipped {
+                        Image(content.hangulCards[content.unitIndex].name)
+                            .resizable()
+                            .frame(width: isLearningView ? 180 : 130 , height: isLearningView ? 180 : 130)
+                        ZStack{
+                            Text(content.hangulCards[content.unitIndex].sound)
+                                .fontWeight(.bold)
+                                .font( isLearningView ? .largeTitle : .title2)
+                            Text("[   ]")
+                                .fontWeight(.bold)
+                                .font( isLearningView ? .largeTitle : .title2)
+                                .foregroundColor(Color(uiColor: .systemGray4))
+                        }
+                    } else {
+                        LottieView(fileName: content.hangulCards[content.unitIndex].name)
+                            .frame(width: isLearningView ? 180 : 130 , height: isLearningView ? 180 : 130)
+                            .scaleEffect(x: -1, y: 1)
+                        HStack{
+                            Spacer()
+                            
+                            Text("[")
+                                .fontWeight(.bold)
+                                .font( isLearningView ? .largeTitle : .title2)
+                                .foregroundColor(Color(uiColor: .systemGray4))
+                            +
+                            Text(content.hangulCards[content.unitIndex].lottieName)
+                                .fontWeight(.bold)
+                                .font( isLearningView ? .largeTitle : .title2)
+                            +
+                            Text("]")
+                                .fontWeight(.bold)
+                                .font( isLearningView ? .largeTitle : .title2)
+                                .foregroundColor(Color(uiColor: .systemGray4))
+                            
+                            Spacer()
+                        }
                         .scaleEffect(x: -1, y: 1)
-                    ZStack{
-                        Text("[")
-                            .fontWeight(.bold)
-                            .font(.largeTitle)
-                            .foregroundColor(Color(uiColor: .systemGray4))
-                        +
-                        Text(content.hangulCards[content.unitIndex].lottieName)
-                            .fontWeight(.bold)
-                            .font(.largeTitle)
-                        +
-                        Text("]")
-                            .fontWeight(.bold)
-                            .font(.largeTitle)
-                            .foregroundColor(Color(uiColor: .systemGray4))
                     }
-                    .scaleEffect(x: -1, y: 1)
                 }
+                .padding(EdgeInsets(top: isLearningView ? 50 : 20 , leading: 0, bottom: isLearningView ? 40 : 20, trailing: 0))
+                Spacer()
             }
-            .padding(EdgeInsets(top: 50, leading: 30, bottom: 40, trailing: 30))
         }
         .overlay(RoundedRectangle(cornerRadius: 24)
             .stroke(isOnceFlipped ? Color(uiColor: .systemGray4) : .blue , lineWidth: 11))
@@ -60,6 +71,9 @@ struct HangulCardView: View {
                           axis: (x: 0.0, y: 1.0, z: 0.0))
         .animation(.easeInOut(duration: 0.5), value: isFlipped)
         .onTapGesture {
+            if !isOnceFlipped {
+                touchCardsCount += 1
+            }
             isFlipped.toggle()
             isOnceFlipped = true
         }
@@ -67,5 +81,5 @@ struct HangulCardView: View {
 }
 
 #Preview {
-    HangulCardView(content: .constant(HangulUnit(unitName: "consonants1", unitIndex: 0, hangulCards: HangulCard.preview)), isOnceFlipped: .constant(false), isFlipped: .constant(false), lottieView: LottieView(fileName: "ㄱ"))
+    HangulCardView(content: .constant(HangulUnit(unitName: "consonants1", unitIndex: 0, hangulCards: HangulCard.preview)), isLearningView: .constant(true), touchCardsCount: .constant(0), isOnceFlipped: .constant(false), isFlipped: .constant(false), lottieView: LottieView(fileName: "ㄱ"))
 }

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationLearningView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationLearningView.swift
@@ -8,24 +8,102 @@
 import SwiftUI
 
 struct HangulEducationLearningView: View {
+    @State var islearningView = true
     @Binding var content : HangulUnit
+    @Binding var touchCardsCount : Int
     @Binding var isOnceFlipped : Bool
     @Binding var isFlipped: Bool
+    @Binding var isExample1Listened : Bool
+    @Binding var isExample2Listened : Bool
+    @Namespace var bottomID
+    let ttsManager = TTSManager()
     
     var body: some View {
-        VStack(spacing: 98){
-            HStack{
-                Text("Focus on form and pronunciation")
-                    .font(.title2)
-                    .fontWeight(.bold)
-                Spacer()
+        ScrollViewReader{ proxy in
+            ScrollView{
+                VStack(spacing: 50){
+                    HStack{
+                        Text("Touch the Cards")
+                            .font(.title2)
+                            .fontWeight(.bold)
+                        ZStack{
+                            Text("\(touchCardsCount)/3")
+                                .font(.body)
+                                .fontWeight(.bold)
+                        }
+                        .padding(EdgeInsets(top: 3, leading: 5, bottom: 3, trailing: 5))
+                        .overlay(RoundedRectangle(cornerRadius: 8)
+                            .stroke(.blue , lineWidth: 3))
+                        Spacer()
+                    }
+                    .padding(.top, 16)
+                    VStack(spacing: 25){
+                        HangulCardView(content: $content, isLearningView: $islearningView, touchCardsCount: $touchCardsCount, isOnceFlipped: $isOnceFlipped, isFlipped: $isFlipped, lottieView: LottieView(fileName: content.hangulCards[content.unitIndex].name))
+                        HStack(spacing: 25){
+                            HStack{
+                                Spacer()
+                                Text(content.hangulCards[content.unitIndex].example1)
+                                    .font(.largeTitle)
+                                    .fontWeight(.bold)
+                                    .padding(15)
+                                
+                                Spacer()
+                            }
+                            .overlay(RoundedRectangle(cornerRadius: 24)
+                                .stroke(isExample1Listened ? Color(uiColor: .systemGray4) : .blue , lineWidth: 11))
+                            .onTapGesture {
+                                if !isExample1Listened {
+                                    touchCardsCount += 1
+                                }
+                                withAnimation(.easeIn(duration: 0.5)){
+                                    isExample1Listened = true
+                                }
+                                ttsManager.play(content.hangulCards[content.unitIndex].example1)
+                            }
+                            HStack{
+                                Spacer()
+                                Text(content.hangulCards[content.unitIndex].example2)
+                                    .font(.largeTitle)
+                                    .fontWeight(.bold)
+                                    .padding(15)
+                                
+                                Spacer()
+                            }
+                            .overlay(RoundedRectangle(cornerRadius: 24)
+                                .stroke(isExample2Listened ? Color(uiColor: .systemGray4) : .blue , lineWidth: 11))
+                            .onTapGesture {
+                                if !isExample2Listened {
+                                    touchCardsCount += 1
+                                }
+                                withAnimation(.easeIn(duration: 0.5)){
+                                    isExample2Listened = true
+                                }
+                                ttsManager.play(content.hangulCards[content.unitIndex].example2)
+                            }
+                        }
+                        Rectangle()
+                            .frame(height: 1)
+                            .foregroundColor(.clear)
+                            .id(bottomID)
+                    }
+                    .padding(.horizontal, 61)
+                    .onChange(of: (!(content.unitIndex == 0) || !isOnceFlipped || !isExample1Listened || !isExample2Listened)) {
+                        DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                            withAnimation(.easeOut(duration: 0.3)) {
+                                proxy.scrollTo(bottomID)
+                            }
+                        }
+                    }
+                }
             }
-            
-            HangulCardView(content: $content, isOnceFlipped: $isOnceFlipped, isFlipped: $isFlipped, lottieView: LottieView(fileName: content.hangulCards[content.unitIndex].name))
+//            .scrollDisabled(!(content.unitIndex == 0) || !isOnceFlipped || !isExample1Listened || !isExample2Listened)
         }
     }
 }
 
+
 #Preview {
-    HangulEducationLearningView(content: .constant(HangulUnit(unitName: "consonants1", unitIndex: 0, hangulCards: HangulCard.preview)), isOnceFlipped: .constant(false), isFlipped: .constant(false))
+    HangulEducationLearningView(content: .constant(HangulUnit(unitName: "consonants1", unitIndex: 0, hangulCards: HangulCard.preview)), touchCardsCount: .constant(0), isOnceFlipped: .constant(false), isFlipped: .constant(false), isExample1Listened: .constant(false), isExample2Listened: .constant(false))
 }
+
+

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationOnboardingView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationOnboardingView.swift
@@ -1,0 +1,56 @@
+//
+//  HangulEducationOnboardingView.swift
+//  Orum
+//
+//  Created by Youngbin Choi on 11/6/23.
+//
+
+import SwiftUI
+
+struct HangulEducationOnboardingView: View {
+    var body: some View {
+        VStack(spacing: 71) {
+            HStack{
+                Text("Before Learing Consonant")
+                    .font(.title2)
+                    .fontWeight(.bold)
+                Spacer()
+            }
+            VStack(spacing: 32 ){
+                VStack{
+                    Image(systemName: "rectangle.fill.on.rectangle.fill")
+                        .font(.largeTitle)
+                        .foregroundColor(.blue)
+                        .padding(.bottom, 8)
+                    Text("For the accurate pronunciation, Listen to the sound through a small card with Hangul written on it.")
+                        .font(.body)
+                        .fontWeight(.bold)
+                        .multilineTextAlignment(.center)
+                    Text("Pronunciation through the alphabet is not completely accurate.")
+                        .font(.body)
+                        .foregroundColor(Color(uiColor: .secondaryLabel))
+                        .multilineTextAlignment(.center)
+                }
+                VStack{
+                    Image(systemName: "speaker.wave.2.fill")
+                        .font(.largeTitle)
+                        .foregroundColor(.blue)
+                        .padding(.bottom, 8)
+                    Text("The basic vowels ㅏ[a] and ㅜ[u] will be used to make sound of consonant.")
+                        .font(.body)
+                        .fontWeight(.bold)
+                        .multilineTextAlignment(.center)
+                    Text("Hangul does not make sounds with consonants alone.")
+                        .font(.body)
+                        .foregroundColor(Color(uiColor: .secondaryLabel))
+                        .multilineTextAlignment(.center)
+                }
+            }
+            .padding(.horizontal, 31)
+        }
+    }
+}
+
+#Preview {
+    HangulEducationOnboardingView()
+}

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationQuizView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationQuizView.swift
@@ -18,105 +18,121 @@ struct HangulEducationQuizView: View {
     @State var answerIndex : Int = 5
     @State var isFinishButtonPressed: Bool = false
     @State var optionAlphabet : [Character] = []
+    @Namespace var bottomID
     
     var body: some View {
-        VStack(spacing: 74){
-            HStack{
-                Text("Select appropriate pronunciation of underlined letter")
-                    .font(.title2)
-                    .fontWeight(.bold)
-                Spacer()
-            }
-            VStack(spacing: 16) {
-                HStack{
-                    Spacer()
-                    ZStack(alignment: .leading){
-                        Text(content.hangulCards[content.unitIndex].quiz.prefix(1))
+        ScrollViewReader{ proxy in
+            ScrollView{
+                VStack(spacing: 74){
+                    HStack {
+                        Text("Select appropriate pronunciation of underlined letter")
+                            .font(.title2)
                             .fontWeight(.bold)
-                            .font(.largeTitle)
-                            .padding(.bottom, 10)
-                            .foregroundColor(.clear)
-                            .underline(true, color: Color(uiColor: .label))
-                            .offset(y: 8)
-                        Text(content.hangulCards[content.unitIndex].quiz)
-                            .fontWeight(.bold)
-                            .font(.largeTitle)
-                            .foregroundColor(Color(uiColor: .label))
                     }
-                    Spacer()
-                }
-                .padding(.vertical, 20)
-                .overlay(RoundedRectangle(cornerRadius: 24)
-                    .stroke(Color(uiColor: .systemGray4) , lineWidth: 8))
-                VStack{
-                    ForEach(0..<optionAlphabet.count, id: \.self) { index in
-                        
-                        let optionColor = fetchOptionColor(index: index)
-                        ZStack{
-                            HStack(spacing: 20){
-                                Circle()
-                                    .strokeBorder(.blue, lineWidth: 3)
-                                    .frame(width: 20, height: 20)
-                                    .overlay {
-                                        Circle()
-                                            .frame(width: 20, height: 20)
-                                            .foregroundColor(optionColor.circle)
-                                    }
-                                ZStack{
-                                    Text("\(String(optionAlphabet[index]))")
-                                        .fontWeight(.bold)
-                                        .font(.title2)
-                                        .foregroundColor(optionColor.text)
-                                    +
-                                    Text("a")
-                                        .fontWeight(.bold)
-                                        .font(.title2)
-                                        .foregroundColor(optionColor.bracket)
-                                Text("[      ]")
+                    VStack(spacing: 16) {
+                        HStack{
+                            Spacer()
+                            ZStack(alignment: .leading){
+                                Text(content.hangulCards[content.unitIndex].quiz.prefix(1))
                                     .fontWeight(.bold)
-                                    .font(.title2)
-                                    .foregroundColor(optionColor.bracket)
+                                    .font(.largeTitle)
+                                    .padding(.bottom, 10)
+                                    .foregroundColor(.clear)
+                                    .underline(true, color: Color(uiColor: .label))
+                                    .offset(y: 8)
+                                Text(content.hangulCards[content.unitIndex].quiz)
+                                    .fontWeight(.bold)
+                                    .font(.largeTitle)
+                                    .foregroundColor(Color(uiColor: .label))
+                            }
+                            Spacer()
+                        }
+                        .padding(.vertical, 20)
+                        .overlay(RoundedRectangle(cornerRadius: 24)
+                            .stroke(Color(uiColor: .systemGray4) , lineWidth: 8))
+                        VStack{
+                            ForEach(0..<optionAlphabet.count, id: \.self) { index in
+                                
+                                let optionColor = fetchOptionColor(index: index)
+                                ZStack{
+                                    HStack(spacing: 20){
+                                        Circle()
+                                            .strokeBorder(.blue, lineWidth: 3)
+                                            .frame(width: 20, height: 20)
+                                            .overlay {
+                                                Circle()
+                                                    .frame(width: 20, height: 20)
+                                                    .foregroundColor(optionColor.circle)
+                                            }
+                                        ZStack{
+                                            Text("\(String(optionAlphabet[index]))")
+                                                .fontWeight(.bold)
+                                                .font(.title2)
+                                                .foregroundColor(optionColor.text)
+                                            +
+                                            Text("a")
+                                                .fontWeight(.bold)
+                                                .font(.title2)
+                                                .foregroundColor(optionColor.bracket)
+                                            Text("[      ]")
+                                                .fontWeight(.bold)
+                                                .font(.title2)
+                                                .foregroundColor(optionColor.bracket)
+                                        }
+                                        Spacer()
+                                    }
+                                    .padding()
                                 }
-                                Spacer()
+                                .overlay(RoundedRectangle(cornerRadius: 15.0)
+                                    .stroke(optionColor.border, lineWidth: 4))
+                                .onTapGesture {
+                                    if !isOptionSubmitted {
+                                        selectedOptionIndex = index
+                                        isOptionSelected = true
+                                    }
+                                    if String(optionAlphabet[index]) == content.hangulCards[content.unitIndex].sound {
+                                        answerIndex = index
+                                    }
+                                    
+                                }
+                                .onAppear {
+                                    if String(optionAlphabet[index]) == content.hangulCards[content.unitIndex].sound {
+                                        answerIndex = index
+                                    }
+                                }
+                                .onChange(of: isOptionSubmitted) { _ in
+                                    if answerIndex != selectedOptionIndex && isOptionSubmitted {
+                                        isOptionWrong = true
+                                    }
+                                    
+                                }
                             }
-                            .padding()
                         }
-                        .overlay(RoundedRectangle(cornerRadius: 15.0)
-                            .stroke(optionColor.border, lineWidth: 4))
-                        .onTapGesture {
-                            if !isOptionSubmitted {
-                                selectedOptionIndex = index
-                                isOptionSelected = true
-                            }
-                           
-                        }
-                        .onAppear {
-                            if String(optionAlphabet[index]) == content.hangulCards[content.unitIndex].sound {
-                                answerIndex = index
-                            }
-                        }
-                        .onChange(of: isOptionSubmitted) { _ in
-                            if answerIndex != selectedOptionIndex && isOptionSubmitted {
-                                isOptionWrong = true
-                            }
-                            if String(optionAlphabet[index]) == content.hangulCards[content.unitIndex].sound {
-                                answerIndex = index
-                            }
+                        Rectangle()
+                            .frame(height: 1)
+                            .foregroundColor(.clear)
+                            .id(bottomID)
+                    }
+                    .padding(.horizontal, 20)
+                    
+                }
+                .onAppear{
+                    optionAlphabet = makeQuizs()
+                }
+                .onChange(of: content.unitIndex) {
+                    selectedOptionIndex = 5
+                    answerIndex = 5
+                    isFinishButtonPressed = false
+                    optionAlphabet = makeQuizs()
+                }
+                .onChange(of: isOptionSubmitted) { _ in
+                    DispatchQueue.main.asyncAfter(deadline: .now() + 0.2) {
+                        withAnimation(.easeOut(duration: 0.3)) {
+                            proxy.scrollTo(bottomID)
                         }
                     }
                 }
             }
-            .padding(.horizontal, 20)
-            
-        }
-        .onAppear{
-            optionAlphabet = makeQuizs()
-        }
-        .onChange(of: content.unitIndex) {
-            selectedOptionIndex = 5
-            answerIndex = 5
-            isFinishButtonPressed = false
-            optionAlphabet = makeQuizs()
         }
     }
     

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationRecapView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationRecapView.swift
@@ -8,11 +8,39 @@
 import SwiftUI
 
 struct HangulEducationRecapView: View {
+    
+    @State var islearningView = false
+    @Binding var content : HangulUnit
+    @State var touchCardsCount : Int = 0
+    @State var isOnceFlipped : Bool = false
+    @State var isFlipped : Bool = false
+    
+    
     var body: some View {
-        Text("Recap")
+        ScrollView{
+            VStack(spacing: 32){
+                HStack{
+                    Text("Recap what you learned to prepare Quiz session")
+                        .font(.title2)
+                        .bold()
+                    Spacer()
+                }
+                .padding(.top, 16)
+                VStack{
+                    LazyVGrid(columns: [GridItem(.flexible(), spacing: 25), GridItem(.flexible())], spacing: 25) {
+                        ForEach(0..<content.hangulCards.count, id: \.self) { index in
+                            let hangulCard = content.hangulCards[index]
+                            HangulCardView(content: $content, isLearningView: $islearningView, touchCardsCount: $touchCardsCount, isOnceFlipped: $isOnceFlipped, isFlipped: $isFlipped, lottieView: LottieView(fileName: content.hangulCards[content.unitIndex].name))
+                        }
+                    }
+                }
+                .padding(.horizontal, 7)
+                .padding(.bottom, 85)
+            }
+        }
     }
 }
 
 #Preview {
-    HangulEducationRecapView()
+    HangulEducationRecapView(content: .constant(HangulUnit(unitName: "consonants1", unitIndex: 0, hangulCards: HangulCard.preview)))
 }

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationView.swift
@@ -10,11 +10,14 @@ import SwiftUI
 struct HangulEducationView: View {
     
     @Binding var isPresented: Bool
-    @State var currentEducation: CurrentEducation = .learning
+    @State var currentEducation: CurrentEducation = .onboarding
     @State var content: HangulUnit
     @State var quizContent: HangulUnit
     @State var progressValue : Int = 0
+    @State var touchCardsCount : Int = 0
     @State var isOnceFlipped : Bool = false
+    @State var isExample1Listened : Bool = false
+    @State var isExample2Listened : Bool = false
     @State var isFlipped: Bool = false
     
     @State var isOptionSelected : Bool = false
@@ -27,99 +30,203 @@ struct HangulEducationView: View {
             ZStack {
                 VStack(spacing: 0){
                     VStack{
-                        ProgressView(value: Double(progressValue) / Double(content.hangulCards.count * 3 - 1))
-                            
+                        ProgressView(value: Double(progressValue) / Double(content.hangulCards.count * 3))
                     }
                     .padding(16)
-                    
                     Divider()
-                    
                     switch currentEducation {
-                    case .learning:
-                        HangulEducationLearningView(content: $content, isOnceFlipped: $isOnceFlipped, isFlipped: $isFlipped)
+                    case .onboarding:
+                        HangulEducationOnboardingView()
                             .padding(16)
+                    case .learning:
+                        HangulEducationLearningView(content: $content, touchCardsCount: $touchCardsCount, isOnceFlipped: $isOnceFlipped, isFlipped: $isFlipped, isExample1Listened: $isExample1Listened, isExample2Listened: $isExample2Listened)
+                            .padding(EdgeInsets(top: 0, leading: 16, bottom: 0, trailing: 16))
                             .transition(.opacity)
+                    case .recap:
+                        ZStack{
+                            HangulEducationRecapView(content: $content)
+                                .padding(.horizontal, 16)
+                                
+                            VStack{
+                                Spacer()
+                                Button {
+                                    progressValue += 1
+                                    currentEducation = .quiz
+                                } label: {
+                                    HStack{
+                                        Spacer()
+                                        Text("Ready to Quiz")
+                                        Spacer()
+                                    }
+                                    .padding(.vertical, 5)
+                                }
+                                .buttonStyle(.borderedProminent)
+                                .padding(EdgeInsets(top: 16, leading: 16, bottom: 50, trailing: 16))
+                                .background(
+                                    LinearGradient(gradient: Gradient(colors: [Color(uiColor: .systemBackground).opacity(0.0), Color(uiColor: .systemBackground).opacity(1.0)]), startPoint: .top, endPoint: .bottom)
+                                )
+                            }
+                        }
                     case .quiz:
                         HangulEducationQuizView(content: $quizContent, isOptionSelected: $isOptionSelected, isOptionSubmitted: $isOptionSubmitted, isOptionWrong: $isOptionWrong)
                             .padding(16)
-                    case .recap:
-                        HangulEducationRecapView()
-                            .padding(16)
+                            .transition(.opacity)
+                        
                     }
                     
-                    Spacer()
-                    VStack{
-                        switch currentEducation {
-                        case .learning:
+                    switch currentEducation {
+                    case .onboarding:
+                        Spacer()
+                        VStack{
                             Button(action: {
-                                if  content.unitIndex < content.hangulCards.count - 1 {
-                                        content.unitIndex += 1
-                                    progressValue += 1
-                                } else {
-                                    withAnimation(.easeIn(duration: 1)) {
-                                        content.unitIndex = 0
-                                        progressValue += 1
-                                        currentEducation = .quiz
-                                    }
-                                }
-                                isOnceFlipped = false
-                                isFlipped = false
+                                currentEducation = .learning
+                                progressValue += 1
                             }){
                                 HStack{
                                     Spacer()
-                                    Text("Got it!")
+                                    Text("Continue")
                                     Spacer()
                                 }
                                 .padding(.vertical, 5)
                             }
                             .buttonStyle(.borderedProminent)
-                            .disabled(!isOnceFlipped)
-                        case .quiz:
-                            Button(action: {
-                                if quizButtonText == "Check" {
-                                    isOptionSubmitted = true
-                                    quizButtonText = "Got it"
-                                    return
-                                }
-                                if  quizContent.unitIndex < quizContent.hangulCards.count - 1 {
-                                    if isOptionWrong {
-                                        quizContent.hangulCards.append(quizContent.hangulCards[quizContent.unitIndex])
-                                    } else {
-                                        progressValue += 1
-                                    }
-                                    quizContent.unitIndex += 1
-                                    quizButtonText = "Check"
-                                    isOptionSelected = false
-                                    isOptionSubmitted = false
-                                    isOptionWrong = false
-                                }
-                                else {
-                                    withAnimation(.easeIn(duration: 1)) {
-                                        currentEducation = .recap
-                                        progressValue += 1
-                                    }
-                                }
-                            }){
-                                HStack{
-                                    Spacer()
-                                    Text(quizButtonText)
-                                    Spacer()
-                                }
-                                .padding(.vertical, 5)
-                            }
-                            .buttonStyle(.borderedProminent)
-                            .tint(!isOptionWrong ? .blue : .red)
-                            .disabled(!isOptionSelected)
-                        case .recap:
-                            Button(action: /*@START_MENU_TOKEN@*/{}/*@END_MENU_TOKEN@*/, label: {
-                                /*@START_MENU_TOKEN@*/Text("Button")/*@END_MENU_TOKEN@*/
-                            })
                         }
+                        .padding(EdgeInsets(top: 16, leading: 16, bottom: 50, trailing: 16))
+                    case .learning:
+                        Spacer()
+                        ZStack{
+                            VStack(spacing: 0){
+                                if (content.unitIndex == 0 && isOnceFlipped && isExample1Listened && isExample2Listened){
+                                    VStack{
+                                        Rectangle()
+                                            .frame(height: 5)
+                                            .foregroundColor(.blue)
+                                        VStack(alignment: .leading, spacing: 16){
+                                            HStack{
+                                                Image(systemName: "info.circle.fill")
+                                                    .font(.title2)
+                                                    .foregroundColor(.blue)
+                                                Text("info")
+                                                    .font(.title2)
+                                                    .fontWeight(.bold)
+                                                    .foregroundColor(.blue)
+                                            }
+                                            Text("\(content.hangulCards[content.unitIndex].name ) has a similar shape and [\(content.hangulCards[content.unitIndex].sound)] sound of \(content.hangulCards[content.unitIndex].lottieName).")
+                                                .fontWeight(.bold)
+                                                .foregroundColor(.blue)
+                                        }
+                                    }
+                                }
+                                VStack{
+                                    Button(action: {
+                                        if  content.unitIndex < content.hangulCards.count - 1 {
+                                            content.unitIndex += 1
+                                            progressValue += 1
+                                        } else {
+                                            withAnimation(.easeIn(duration: 1)) {
+                                                content.unitIndex = 0
+                                                progressValue += 1
+                                                currentEducation = .recap
+                                            }
+                                        }
+                                        withAnimation (.easeIn(duration: 1)){
+                                            isOnceFlipped = false
+                                            isFlipped = false
+                                            isExample1Listened = false
+                                            isExample2Listened = false
+                                            touchCardsCount = 0
+                                        }
+                                    }){
+                                        HStack{
+                                            Spacer()
+                                            Text("Continue")
+                                            Spacer()
+                                        }
+                                        .padding(.vertical, 5)
+                                    }
+                                    .buttonStyle(.borderedProminent)
+                                    .disabled(!isOnceFlipped || !isExample1Listened || !isExample2Listened)
+                                }
+                                .padding(EdgeInsets(top: 16, leading: 16, bottom: 50, trailing: 16))
+                            }
+                        }
+                        .background((content.unitIndex == 0 && isOnceFlipped && isExample1Listened && isExample2Listened) ? .blue.opacity(0.05) : .clear)
+                    case .recap:
+                        EmptyView()
+                            .padding(EdgeInsets(top: 16, leading: 16, bottom: 50, trailing: 16))
+                    case .quiz:
+                        Spacer()
+                        ZStack{
+                            VStack(spacing: 0){
+                                if (isOptionSubmitted ){
+                                    VStack{
+                                        Rectangle()
+                                            .frame(height: 5)
+                                            .foregroundColor(isOptionWrong ? .red : .blue)
+                                        VStack(alignment: .leading, spacing: 16){
+                                            HStack{
+                                                Image(systemName: isOptionWrong ? "exclamationmark.circle.fill" : "checkmark.circle.fill")
+                                                    .font(.title2)
+                                                    .foregroundColor(isOptionWrong ? .red : .blue)
+                                                Text(isOptionWrong ? "Incorrect" : "Correct")
+                                                    .font(.title2)
+                                                    .fontWeight(.bold)
+                                                    .foregroundColor(isOptionWrong ? .red : .blue)
+                                            }
+                                            Text( isOptionWrong ? "ㄱ has a similar shape and [g] sound of gun." : "감사합니다[gamsahabnida] means “Thank you” in Korean.")
+                                                .fontWeight(.bold)
+                                                .foregroundColor(isOptionWrong ? .red : .blue)
+                                        }
+                                    }
+                                }
+                                VStack{
+                                    Button(action: {
+                                        if quizButtonText == "Check" {
+                                            isOptionSubmitted = true
+                                            quizButtonText = "Got it"
+                                            return
+                                        }
+                                        if  quizContent.unitIndex < quizContent.hangulCards.count - 1 {
+                                            if isOptionWrong {
+                                                quizContent.hangulCards.append(quizContent.hangulCards[quizContent.unitIndex])
+                                            } else {
+                                                progressValue += 1
+                                            }
+                                            quizContent.unitIndex += 1
+                                            quizButtonText = "Check"
+                                            isOptionSelected = false
+                                            isOptionSubmitted = false
+                                            isOptionWrong = false
+                                        }
+                                        else {
+                                            withAnimation(.easeIn(duration: 1)) {
+                                                currentEducation = .recap
+                                                progressValue += 1
+                                            }
+                                        }
+                                    }){
+                                        HStack{
+                                            Spacer()
+                                            Text(quizButtonText)
+                                            Spacer()
+                                        }
+                                        .padding(.vertical, 5)
+                                    }
+                                    .buttonStyle(.borderedProminent)
+                                    .tint(!isOptionWrong ? .blue : .red)
+                                    .disabled(!isOptionSelected)
+                                }
+                                .padding(EdgeInsets(top: 16, leading: 16, bottom: 50, trailing: 16))
+                            }
+                        }
+                        .background(
+                            correctionBackground()
+                        )
+
                     }
-                    .padding(16)
-                    
                 }
                 .navigationTitle(content.unitName)
+                .navigationBarTitleDisplayMode(.automatic)
                 .navigationBarItems(leading: Button(action: {
                     isPresented.toggle()
                 }) {
@@ -128,14 +235,27 @@ struct HangulEducationView: View {
                         .symbolRenderingMode(.palette)
                 })
             }
+            .edgesIgnoringSafeArea([.bottom])
+        }
+    }
+    
+    func correctionBackground() -> Color {
+        if isOptionSubmitted && !isOptionWrong {
+            Color.blue.opacity(0.05)
+        }
+        else if isOptionSubmitted && isOptionWrong {
+            Color.red.opacity(0.05)
+        } else {
+            Color.clear
         }
     }
 }
 
 enum CurrentEducation {
+    case onboarding
     case learning
-    case quiz
     case recap
+    case quiz
 }
 
 #Preview {


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->

자음 교육 화면 뷰 구현을 완료하였습니다

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->

 1. 자음 온보딩
 2. 가, 구 소리듣기 View 및 Logic
 3. LearnigView info
 4. RecapView
 5. QuizView Correct, incorrect

## Logic
<!-- 작업 내용 1 -->
```swift
```

 ## 작업 결과(이미지 첨부는 선택)
