### PR TITLE
[Feat/#67] RecapView의 카드가 따로 플립되도록 구현하였습니다

### DIFF
--- a/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationRecapView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationRecapView.swift
@@ -12,9 +12,8 @@ struct HangulEducationRecapView: View {
     @State var islearningView = false
     @Binding var content : HangulUnit
     @State var touchCardsCount : Int = 0
-    @State var isOnceFlipped : Bool = false
-    @State var isFlipped : Bool = false
-    
+    @State var isOnceFlipped : [Bool] = [false,false,false,false,false,false,false,false,false,false] // TODO: HangulCardView
+    @State var isFlipped : [Bool] = [false,false,false,false,false,false,false,false,false,false]
     @Binding var ind: Int
     
     var body: some View {
@@ -30,7 +29,7 @@ struct HangulEducationRecapView: View {
                 VStack{
                     LazyVGrid(columns: [GridItem(.flexible(), spacing: 25), GridItem(.flexible())], spacing: 25) {
                         ForEach(0 ..< content.hangulCards.count, id: \.self) { index in
-                            HangulCardView(hangulCard: $content.hangulCards[index], isLearningView: $islearningView, touchCardsCount: $touchCardsCount, isOnceFlipped: $isOnceFlipped, isFlipped: $isFlipped, lottieView: LottieView(fileName: content.hangulCards[index].name))
+                            HangulCardView(hangulCard: $content.hangulCards[index], isLearningView: $islearningView, touchCardsCount: $touchCardsCount, isOnceFlipped: $isOnceFlipped[index], isFlipped: $isFlipped[index], lottieView: LottieView(fileName: content.hangulCards[index].name))
                         }
                     }
                 }

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationView.swift
@@ -13,7 +13,7 @@ struct HangulEducationView: View {
     
     @EnvironmentObject var educationManager: EducationManager
 
-    @State var currentEducation: CurrentEducation = .learning
+    @State var currentEducation: CurrentEducation = .onboarding
     @State var content: HangulUnit
     @State var quizContent: HangulUnit
     @State var progressValue : Int = 0
@@ -35,7 +35,7 @@ struct HangulEducationView: View {
             ZStack {
                 VStack(spacing: 0){
                     VStack{
-                        ProgressView(value: Double(progressValue) / Double(content.hangulCards.count * 3))
+                        ProgressView(value: Double(progressValue) / Double(content.hangulCards.count * 2 + 2))
                     }
                     .padding(16)
                     
@@ -136,6 +136,7 @@ struct HangulEducationView: View {
                                             index += 1
                                             progressValue += 1
                                         } else {
+                                            isOnceFlipped = false
                                             index = 0
                                             
                                             withAnimation(.easeIn(duration: 1)) {
@@ -190,7 +191,7 @@ struct HangulEducationView: View {
                                                     .fontWeight(.bold)
                                                     .foregroundColor(isOptionWrong ? .red : .blue)
                                             }
-                                            Text( isOptionWrong ? "ㄱ has a similar shape and [g] sound of gun." : "감사합니다[gamsahabnida] means “Thank you” in Korean.")
+                                            Text( isOptionWrong ? "\(content.hangulCards[index].name ) has a similar shape and [\(content.hangulCards[index].sound)] sound of \(content.hangulCards[index].lottieName)." : "감사합니다[gamsahabnida] means “Thank you” in Korean.")
                                                 .fontWeight(.bold)
                                                 .foregroundColor(isOptionWrong ? .red : .blue)
                                         }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->

RecapView의 카드가 따로 플립되도록 구현하였습니다

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->

RecapView의 카드가 따로 플립되도록 구현하였습니다

## Logic
<!-- 작업 내용 1 -->
```swift
@State var isOnceFlipped : [Bool] = [false,false,false,false,false,false,false,false,false,false] // TODO: HangulCardView
@State var isFlipped : [Bool] = [false,false,false,false,false,false,false,false,false,false]
```

 ## 작업 결과(이미지 첨부는 선택)
