### PR TITLE
Feat/#74 implement same card collecting view

### DIFF
--- a/Orum/Orum/Views/DuringFlight/ver 1.1/SameCardCollectingQuizView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/SameCardCollectingQuizView.swift
@@ -33,7 +33,6 @@ struct SameCardCollectingQuizView: View {
                         VStack(spacing: 16){
                             ForEach(0 ..< leftOptionVowels.count, id: \.self ) { index in
                                 Button(action: {
-                                    print("Hi")
                                     if isLeftOptionCorrect[index] {
                                         return
                                     }
@@ -53,11 +52,11 @@ struct SameCardCollectingQuizView: View {
                                         if leftOptionVowels[index] == rightOptionVowels[firstTappedIndex] {
                                             isLeftOptionCorrect[index] = true
                                             isRightOptionCorrect[firstTappedIndex] = true
-                                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.0 , execute: {
+                                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5 , execute: {
                                                 leftOptionReset(index)
                                             })
                                         } else {
-                                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.0 , execute: {
+                                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5 , execute: {
                                                 leftOptionReset(index)
                                             })
                                         }
@@ -96,11 +95,11 @@ struct SameCardCollectingQuizView: View {
                                         if rightOptionVowels[index] == leftOptionVowels[firstTappedIndex] {
                                             isRightOptionCorrect[index] = true
                                             isLeftOptionCorrect[firstTappedIndex] = true
-                                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.0 , execute: {
+                                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5 , execute: {
                                                 rightOptionReset(index)
                                             })
                                         } else {
-                                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.0 , execute: {
+                                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5 , execute: {
                                                 rightOptionReset(index)
                                             })
                                         }
@@ -153,7 +152,7 @@ struct SameCardCollectingQuizView: View {
     
     func makeLeftColor( _ index : Int) -> [Color] {
         if isLeftOptionCorrect[index] {
-            return [Color(uiColor: .systemBlue) , Color(uiColor: .systemBlue)]
+            return [Color(uiColor: .quaternarySystemFill) , Color(uiColor: .quaternarySystemFill)]
         } else if isLeftOptionTapped[index] && bothSideTapped {
             return [Color(uiColor: .systemRed) , Color(uiColor: .systemRed)]
         }
@@ -166,7 +165,7 @@ struct SameCardCollectingQuizView: View {
     
     func makeRightColor( _ index : Int) -> [Color] {
         if isRightOptionCorrect[index] {
-            return [Color(uiColor: .systemBlue) , Color(uiColor: .systemBlue)]
+            return [Color(uiColor: .quaternarySystemFill) , Color(uiColor: .quaternarySystemFill)]
         } else if isRightOptionTapped[index] && bothSideTapped {
             return [Color(uiColor: .systemRed) , Color(uiColor: .systemRed)]
         }

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/SameCardCollectingQuizView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/SameCardCollectingQuizView.swift
@@ -11,18 +11,186 @@ struct SameCardCollectingQuizView: View {
     @Binding var currentEducation: CurrentEducation
     @Binding var progressValue: Int
     
+    @State var firstTappedIndex : Int = 10
+    @State var whichSideFirstTapped : String = ""
+    @State var bothSideTapped : Bool = false
+    @State var leftOptionVowels : [Character] = []
+    @State var rightOptionVowels : [Character] = []
+    @State var isLeftOptionTapped : [Bool] = [false, false, false, false]
+    @State var isRightOptionTapped : [Bool] = [false, false, false, false]
+    @State var isLeftOptionCorrect : [Bool] = [false, false, false, false]
+    @State var isRightOptionCorrect : [Bool] = [false, false, false, false]
     @EnvironmentObject var educationManager: EducationManager
     
     var body: some View {
-        Text("Same Card Collecting Quiz")
-        
-        Button(action: {
-            currentEducation = .quiz
-            progressValue += 1
-        }, label: {
-            Text("Continue")
-        })
-        .buttonStyle(.borderedProminent)
+        ZStack{
+            ScrollView{
+                VStack(alignment: .leading ,  spacing: 32){
+                    Text("Select appropriate vowel of the sound")
+                        .font(.title2)
+                        .fontWeight(.bold)
+                    HStack(spacing: 14){
+                        VStack(spacing: 16){
+                            ForEach(0 ..< leftOptionVowels.count, id: \.self ) { index in
+                                Button(action: {
+                                    print("Hi")
+                                    if isLeftOptionCorrect[index] {
+                                        return
+                                    }
+                                    if whichSideFirstTapped == ""{
+                                        whichSideFirstTapped = "left"
+                                        isLeftOptionTapped[index] = true
+                                        firstTappedIndex = index
+                                    } else if whichSideFirstTapped == "left"{
+                                        for i in 0 ..< isLeftOptionTapped.count {
+                                            isLeftOptionTapped[i] = false
+                                        }
+                                        firstTappedIndex = index
+                                        isLeftOptionTapped[index] = true
+                                    } else if whichSideFirstTapped == "right" {
+                                        bothSideTapped = true
+                                        isLeftOptionTapped[index] = true
+                                        if leftOptionVowels[index] == rightOptionVowels[firstTappedIndex] {
+                                            isLeftOptionCorrect[index] = true
+                                            isRightOptionCorrect[firstTappedIndex] = true
+                                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.0 , execute: {
+                                                leftOptionReset(index)
+                                            })
+                                        } else {
+                                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.0 , execute: {
+                                                leftOptionReset(index)
+                                            })
+                                        }
+                                    }
+                                }, label: {
+                                    Image(systemName: "speaker.wave.3.fill")
+                                        .frame(maxWidth: .infinity)
+                                        .font(.title2)
+                                        .fontWeight(.bold)
+                                        .foregroundColor(makeLeftColor(index)[0])
+                                        .padding(.vertical, 24)
+                                        .overlay(RoundedRectangle(cornerRadius: 24)
+                                            .strokeBorder(makeLeftColor(index)[1], lineWidth: 8.0, antialiased: true))
+                                })
+                            }
+                        }
+                        VStack(spacing: 16){
+                            ForEach(0 ..< rightOptionVowels.count, id: \.self ) { index in
+                                Button(action: {
+                                    if isRightOptionCorrect[index] {
+                                        return
+                                    }
+                                    if whichSideFirstTapped == ""{
+                                        whichSideFirstTapped = "right"
+                                        isRightOptionTapped[index] = true
+                                        firstTappedIndex = index
+                                    } else if whichSideFirstTapped == "right"{
+                                        for i in 0 ..< isRightOptionTapped.count {
+                                            isRightOptionTapped[i] = false
+                                        }
+                                        firstTappedIndex = index
+                                        isRightOptionTapped[index] = true
+                                    } else if whichSideFirstTapped == "left" {
+                                        bothSideTapped = true
+                                        isRightOptionTapped[index] = true
+                                        if rightOptionVowels[index] == leftOptionVowels[firstTappedIndex] {
+                                            isRightOptionCorrect[index] = true
+                                            isLeftOptionCorrect[firstTappedIndex] = true
+                                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.0 , execute: {
+                                                rightOptionReset(index)
+                                            })
+                                        } else {
+                                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.0 , execute: {
+                                                rightOptionReset(index)
+                                            })
+                                        }
+                                    }
+                                }, label: {
+                                    Text("\(String(rightOptionVowels[index]))")
+                                        .frame(maxWidth: .infinity)
+                                        .font(.title2)
+                                        .fontWeight(.bold)
+                                        .foregroundColor(makeRightColor(index)[0])
+                                        .padding(.vertical, 24)
+                                        .overlay(RoundedRectangle(cornerRadius: 24)
+                                            .strokeBorder(makeRightColor(index)[1], lineWidth: 8.0, antialiased: true))
+                                })
+                            }
+                        }
+                    }
+                }
+            }
+            VStack{
+                Spacer()
+                Button(action: {
+                    currentEducation = .quiz
+                    progressValue += 1
+                }, label: {
+                    Text("Continue")
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 8)
+                })
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .onAppear{
+            rightOptionVowels = makeOptions()
+            leftOptionVowels = rightOptionVowels.shuffled()
+            print(leftOptionVowels)
+            print(rightOptionVowels)
+        }
+    }
+    
+    func makeOptions() -> [Character]{
+        var learnedVowels: [Character] = []
+        for i in 0 ..< educationManager.content.count {
+            learnedVowels.append(contentsOf: educationManager.content[i].name)
+        }
+        let shuffledLearnedVowels = learnedVowels.shuffled()
+        let optionVowels = shuffledLearnedVowels.prefix(4).shuffled()
+        return optionVowels
+    }
+    
+    func makeLeftColor( _ index : Int) -> [Color] {
+        if isLeftOptionCorrect[index] {
+            return [Color(uiColor: .systemBlue) , Color(uiColor: .systemBlue)]
+        } else if isLeftOptionTapped[index] && bothSideTapped {
+            return [Color(uiColor: .systemRed) , Color(uiColor: .systemRed)]
+        }
+        else if  isLeftOptionTapped[index]  {
+            return [Color(uiColor: .systemBlue) , Color(uiColor: .systemBlue)]
+        } else {
+            return [Color(uiColor: .systemBlue) , Color(uiColor: .systemFill)]
+        }
+    }
+    
+    func makeRightColor( _ index : Int) -> [Color] {
+        if isRightOptionCorrect[index] {
+            return [Color(uiColor: .systemBlue) , Color(uiColor: .systemBlue)]
+        } else if isRightOptionTapped[index] && bothSideTapped {
+            return [Color(uiColor: .systemRed) , Color(uiColor: .systemRed)]
+        }
+        else if  isRightOptionTapped[index] {
+            return [Color(uiColor: .systemBlue) , Color(uiColor: .systemBlue)]
+        } else {
+            return [Color(uiColor: .systemBlue) , Color(uiColor: .systemFill)]
+        }
+    }
+    
+    func leftOptionReset(_ index : Int) {
+        isLeftOptionTapped[index] = false
+        isRightOptionTapped[firstTappedIndex] = false
+        firstTappedIndex = 10
+        whichSideFirstTapped = ""
+        bothSideTapped = false
+    }
+    
+    func rightOptionReset(_ index : Int) {
+        isRightOptionTapped[index] = false
+        isLeftOptionTapped[firstTappedIndex] = false
+        firstTappedIndex = 10
+        whichSideFirstTapped = ""
+        bothSideTapped = false
     }
 }
 


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->

SameCardCollectingQuizView 를 구현하였습니다

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->

SameCardCollectingQuizView 를 구현하였습니다

## Logic
<!-- 작업 내용 1 -->
```swift
                                    if isLeftOptionCorrect[index] {
                                                                            return
                                                                        }
                                    if whichSideFirstTapped == ""{
                                        whichSideFirstTapped = "left"
                                        isLeftOptionTapped[index] = true
                                        firstTappedIndex = index
                                    } else if whichSideFirstTapped == "left"{
                                        for i in 0 ..< isLeftOptionTapped.count {
                                            isLeftOptionTapped[i] = false
                                        }
                                        firstTappedIndex = index
                                        isLeftOptionTapped[index] = true
                                    } else if whichSideFirstTapped == "right" {
                                        bothSideTapped = true
                                        isLeftOptionTapped[index] = true
                                        if leftOptionVowels[index] == rightOptionVowels[firstTappedIndex] {
                                            isLeftOptionCorrect[index] = true
                                            isRightOptionCorrect[firstTappedIndex] = true
                                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5 , execute: {
                                                leftOptionReset(index)
                                            })
                                        } else {
                                            DispatchQueue.main.asyncAfter(deadline: DispatchTime.now() + 1.5 , execute: {
                                                leftOptionReset(index)
                                            })
                                        }
                                    }
```
화면의 버튼을 클릭하면 경우에 따라 네가지로 분기됩니다
<왼쪽 버튼 클릭의 경우>
1. isLeftOptionCorrect[index] : 정답으로 체크된 버튼은 바로 리턴
2. whichSideFirstTapped == "" : 처음 터치되는 버튼은 자신이 왼쪽버튼인지 오른쪽 버튼인지 변수에 저장 ( whichSideFirstTapped = "left" ) 이후 자신의 인덱스를 변수에 저장 ( firstTappedIndex = index )
3. whichSideFirstTapped == "left" : 이미 왼쪽 버튼이 터치된 상태로 또 왼쪽 버튼이 터치되면, 이전 터치된 버튼의 인덱스를 삭제하고 자신의 인덱스를 전달
4. whichSideFirstTapped == "right" : 이미 오른쪽에 터치된 버튼이 있는 경우에는 bothSideTapped = true 로 해주고
정답체크를 진행한다 이후 버튼 리셋


 ## 작업 결과(이미지 첨부는 선택)
