### PR TITLE
[Feat/#81] 퀴즈 문제 생성 함수를 재작성하였습니다

### DIFF
--- a/Orum/Orum/Constants.swift
+++ b/Orum/Orum/Constants.swift
@@ -64,6 +64,11 @@ struct Constants {
             "ㅌ",
             "ㅍ",
             "ㅎ",
+            "ㄲ",
+            "ㄸ",
+            "ㅃ",
+            "ㅆ",
+            "ㅉ"
         ]
         
         static let consonantExamples: [String : [String]] = [

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationQuizView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationQuizView.swift
@@ -24,7 +24,7 @@ struct HangulEducationQuizView: View {
     @State var selectedOptionIndex : Int = 5
     @State var answerIndex : Int = 5
     @State var isFinishButtonPressed: Bool = false
-    @State var optionAlphabet : [Character] = []
+    @State var optionAlphabet : [String] = []
     @Namespace var bottomID
     
     @State var ind: Int = 0
@@ -88,6 +88,11 @@ struct HangulEducationQuizView: View {
                                                         .foregroundColor(optionColor.circle)
                                                 }
                                             ZStack{
+                                                Text("[")
+                                                    .fontWeight(.bold)
+                                                    .font(.title2)
+                                                    .foregroundColor(optionColor.bracket)
+                                                +
                                                 Text("\(String(optionAlphabet[index]))")
                                                     .fontWeight(.bold)
                                                     .font(.title2)
@@ -97,7 +102,8 @@ struct HangulEducationQuizView: View {
                                                     .fontWeight(.bold)
                                                     .font(.title2)
                                                     .foregroundColor(optionColor.bracket)
-                                                Text("[      ]")
+                                                +
+                                                Text("]")
                                                     .fontWeight(.bold)
                                                     .font(.title2)
                                                     .foregroundColor(optionColor.bracket)
@@ -268,17 +274,41 @@ struct HangulEducationQuizView: View {
         }
     }
     
-    func makeQuizs() -> [Character] { // TODO: 알파벳이 두 개인 경우 (ㅊ, 쌍자음, 모음)
-        let alphabet: String = "abcdefghijklmnopqrstuvwxyz"
-        let answerFilter: Character = Character(String(educationManager.quiz.isEmpty ? " " : educationManager.quiz[ind].sound))
-        let tempOptionAlphabet: String = String(alphabet.filter { $0 != answerFilter })
-        if !educationManager.quiz.isEmpty {
-            return (String(tempOptionAlphabet.shuffled().prefix(3)) +  educationManager.quiz[ind].sound).shuffled()
+    func makeQuizs() -> [String] { // TODO: 알파벳이 두 개인 경우 (ㅊ, 쌍자음, 모음)
+        if educationManager.chapterType == .consonant{
+            let answerConsonant = educationManager.quiz[ind].sound
+            var consonantsSoundList : [String] = []
+            for i in  0 ..< Constants.Hangul.consonants.count {
+                consonantsSoundList.append(Constants.Hangul.consonantSound[Constants.Hangul.consonants[i]]!)
+            }
+            let answerIndex = consonantsSoundList.firstIndex(of: answerConsonant)!
+            consonantsSoundList.remove(at: answerIndex)
+            var shuffledConsonantsSoundList = consonantsSoundList.shuffled().prefix(3)
+            shuffledConsonantsSoundList.append(answerConsonant)
+            
+            return Array(shuffledConsonantsSoundList)
+        } else if educationManager.chapterType == .vowel{
+            let answerVowel = educationManager.quiz[ind].sound
+            var vowelsSoundList : [String] = []
+            for i in  0 ..< Constants.Hangul.vowels.count {
+                vowelsSoundList.append(Constants.Hangul.vowelSound[Constants.Hangul.vowels[i]]!)
+            }
+            let answerIndex = vowelsSoundList.firstIndex(of: answerVowel)!
+            vowelsSoundList.remove(at: answerIndex)
+            var shuffledVowelsSoundList = vowelsSoundList.shuffled().prefix(3)
+            shuffledVowelsSoundList.append(answerVowel)
+            return Array(shuffledVowelsSoundList)
         }
-        else {
-            return [Character("")]
-        }
-        
+//        let alphabet: String = "abcdefghijklmnopqrstuvwxyz"
+//        let answerFilter: Character = Character(String(educationManager.quiz.isEmpty ? " " : educationManager.quiz[ind].sound))
+//        let tempOptionAlphabet: String = String(alphabet.filter { $0 != answerFilter })
+//        if !educationManager.quiz.isEmpty {
+//            return (String(tempOptionAlphabet.shuffled().prefix(3)) +  educationManager.quiz[ind].sound).shuffled()
+//        }
+//        else {
+//            return [Character("")]
+//        }
+        return []
     }
     
     func fetchOptionColor(index: Int) -> OptionColor {


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->

 퀴즈 문제 생성 함수를 재작성하였습니다

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->
1. 보기는 자음 모음에서 출제되도록 하였습니다
2. 두글자, 세글자(ㅊ, 쌍자음)에서도 대응되도록 하였습니다
3. 모음의 경우에도 보기가 모음의 리스트에서 출제되고, 여러글자 모음에서도 대응되도록 하였습니다

## Logic
<!-- 작업 내용 1 -->
```swift
func makeQuizs() -> [String] { // TODO: 알파벳이 두 개인 경우 (ㅊ, 쌍자음, 모음)
        if educationManager.chapterType == .consonant{
            let answerConsonant = educationManager.quiz[ind].sound
            var consonantsSoundList : [String] = []
            for i in  0 ..< Constants.Hangul.consonants.count {
                consonantsSoundList.append(Constants.Hangul.consonantSound[Constants.Hangul.consonants[i]]!)
            }
            let answerIndex = consonantsSoundList.firstIndex(of: answerConsonant)!
            consonantsSoundList.remove(at: answerIndex)
            var shuffledConsonantsSoundList = consonantsSoundList.shuffled().prefix(3)
            shuffledConsonantsSoundList.append(answerConsonant)
            
            return Array(shuffledConsonantsSoundList)
        } 
```

 ## 작업 결과(이미지 첨부는 선택)
