### PR TITLE
[Feat/#83] Vowel Education Complete

### DIFF
--- a/Orum/Orum.xcodeproj/project.pbxproj
+++ b/Orum/Orum.xcodeproj/project.pbxproj
@@ -33,6 +33,10 @@
 		937620392AF0808700DE2C50 /* GameView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 937620382AF0808700DE2C50 /* GameView.swift */; };
 		9376203B2AF0808F00DE2C50 /* StorageView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9376203A2AF0808F00DE2C50 /* StorageView.swift */; };
 		9376203D2AF080B500DE2C50 /* HangulEducationView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9376203C2AF080B500DE2C50 /* HangulEducationView.swift */; };
+		93D529752B0301A500DA743E /* BatchimOnboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D529742B0301A500DA743E /* BatchimOnboarding.swift */; };
+		93D529772B0311EF00DA743E /* BasicVowelCheckView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D529762B0311EF00DA743E /* BasicVowelCheckView.swift */; };
+		93D529792B031BFB00DA743E /* QuizLessonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D529782B031BFB00DA743E /* QuizLessonView.swift */; };
+		93D5297B2B031C0500DA743E /* PrologueView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93D5297A2B031C0500DA743E /* PrologueView.swift */; };
 		93DA78E72AFB2047004BB43F /* ConsonantLearningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93DA78E62AFB2047004BB43F /* ConsonantLearningView.swift */; };
 		93DA78E92AFB2052004BB43F /* VowelLearningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93DA78E82AFB2052004BB43F /* VowelLearningView.swift */; };
 		93DA78EF2AFB6233004BB43F /* VowelDrawingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93DA78EE2AFB6233004BB43F /* VowelDrawingView.swift */; };
@@ -104,6 +108,10 @@
 		9376203A2AF0808F00DE2C50 /* StorageView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StorageView.swift; sourceTree = "<group>"; };
 		9376203C2AF080B500DE2C50 /* HangulEducationView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulEducationView.swift; sourceTree = "<group>"; };
 		93D0BDA52AE2B54E00455447 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
+		93D529742B0301A500DA743E /* BatchimOnboarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BatchimOnboarding.swift; sourceTree = "<group>"; };
+		93D529762B0311EF00DA743E /* BasicVowelCheckView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BasicVowelCheckView.swift; sourceTree = "<group>"; };
+		93D529782B031BFB00DA743E /* QuizLessonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuizLessonView.swift; sourceTree = "<group>"; };
+		93D5297A2B031C0500DA743E /* PrologueView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PrologueView.swift; sourceTree = "<group>"; };
 		93DA78E62AFB2047004BB43F /* ConsonantLearningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsonantLearningView.swift; sourceTree = "<group>"; };
 		93DA78E82AFB2052004BB43F /* VowelLearningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VowelLearningView.swift; sourceTree = "<group>"; };
 		93DA78EE2AFB6233004BB43F /* VowelDrawingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VowelDrawingView.swift; sourceTree = "<group>"; };
@@ -279,6 +287,8 @@
 				93419DCD2AF0AA7100DCB322 /* StorageDetailView.swift */,
 				D9037D0A2AF11FD50098DB57 /* HangulEducationRecapView.swift */,
 				93DA78F02AFB6912004BB43F /* SameCardCollectingQuizView.swift */,
+				93D529782B031BFB00DA743E /* QuizLessonView.swift */,
+				93D5297A2B031C0500DA743E /* PrologueView.swift */,
 			);
 			path = "ver 1.1";
 			sourceTree = "<group>";
@@ -310,6 +320,7 @@
 				93DA78E62AFB2047004BB43F /* ConsonantLearningView.swift */,
 				93DA78E82AFB2052004BB43F /* VowelLearningView.swift */,
 				93DA78EE2AFB6233004BB43F /* VowelDrawingView.swift */,
+				93D529762B0311EF00DA743E /* BasicVowelCheckView.swift */,
 			);
 			path = LearningView;
 			sourceTree = "<group>";
@@ -320,6 +331,7 @@
 				93DA78F32AFB6B35004BB43F /* ConsonantOnboarding.swift */,
 				93DA78F52AFB6B4A004BB43F /* VowelOnboarding.swift */,
 				93DA78F72AFB6B5A004BB43F /* SystemOnboarding.swift */,
+				93D529742B0301A500DA743E /* BatchimOnboarding.swift */,
 			);
 			path = OnboardingView;
 			sourceTree = "<group>";
@@ -442,7 +454,9 @@
 			buildActionMask = 2147483647;
 			files = (
 				9336E1FD2AF78B4A000B9E76 /* FlightManager.swift in Sources */,
+				93D5297B2B031C0500DA743E /* PrologueView.swift in Sources */,
 				D967D1C72AE2C761008B3379 /* UIColor+Hex.swift in Sources */,
+				93D529792B031BFB00DA743E /* QuizLessonView.swift in Sources */,
 				D967D1C92AE40F4E008B3379 /* TTSManager.swift in Sources */,
 				937620392AF0808700DE2C50 /* GameView.swift in Sources */,
 				933A8E522ADD1B2E002AE727 /* FlightInfoSubmitView.swift in Sources */,
@@ -468,6 +482,7 @@
 				D9037D092AF0D2B70098DB57 /* HangulCardView.swift in Sources */,
 				93576C302AEF5E9100CCB3B3 /* String+TransformStringToDate.swift in Sources */,
 				D950CF612AE125AF00BD9EB3 /* FlightInfoEditView.swift in Sources */,
+				93D529752B0301A500DA743E /* BatchimOnboarding.swift in Sources */,
 				D90B0DFC2AF8697000401C87 /* HangulEducationOnboardingView.swift in Sources */,
 				93DA78F62AFB6B4A004BB43F /* VowelOnboarding.swift in Sources */,
 				933A8E502ADD1AF6002AE727 /* TripRemainingDayView.swift in Sources */,
@@ -476,10 +491,11 @@
 				93DA78E92AFB2052004BB43F /* VowelLearningView.swift in Sources */,
 				D950CF652AE127C600BD9EB3 /* FlightCodeAPIData.swift in Sources */,
 				937620372AF0807F00DE2C50 /* LearnView.swift in Sources */,
-				93419DCE2AF0AA7100DCB322 /* SearchResultView.swift in Sources */,
+				93419DCE2AF0AA7100DCB322 /* StorageDetailView.swift in Sources */,
 				D9A9CE0A2AFDF02300F821D6 /* Canvas.swift in Sources */,
 				93419DCE2AF0AA7100DCB322 /* StorageDetailView.swift in Sources */,
 				930F26C92ADD0D8B00896A32 /* OrumApp.swift in Sources */,
+				93D529772B0311EF00DA743E /* BasicVowelCheckView.swift in Sources */,
 				93419DD32AF0AB1600DCB322 /* EducationManager.swift in Sources */,
 				933A8E4C2ADD1A84002AE727 /* Calendar+CompareDays.swift in Sources */,
 				93DA78F12AFB6912004BB43F /* SameCardCollectingQuizView.swift in Sources */,

--- a/Orum/Orum/Constants.swift
+++ b/Orum/Orum/Constants.swift
@@ -10,40 +10,67 @@ import Foundation
 struct Constants {
     struct Chapter {
         static let system: String = "System of Hangul"
-        static let consonant1: String = "Consonant1"
-        static let consonant2: String = "Consonant2"
-        static let consonant3: String = "Consonant3"
-        static let consonant4: String = "Consonant4"
-        static let consonant5: String = "Consonant5"
-        static let vowel1: String = "Vowel1"
-        static let vowel2: String = "Vowel2"
-        static let vowel3: String = "Vowel3"
+        
+        static let consonant0: String = "Consonant 0" // Consonant Prologue
+        static let consonant1: String = "Consonant 1" // ㄱ,ㄴ,ㄷ,ㄹ
+        static let consonant2: String = "Consonant 2" // ㅁ,ㅂ,ㅅ,ㅇ,ㅈ
+        static let consonant3: String = "Consonant 3" // ㅊ,ㅋ,ㅌ,ㅍ,ㅎ
+        static let consonant4: String = "Consonant 4" // ㄲ,ㄸ,ㅃ,ㅆ,ㅉ
+        static let consonant5: String = "Consonant 5" // Consonant Quiz
+        
+        static let vowel0: String = "Vowel 0" // Vowel Prologue
+        static let vowel1: String = "Vowel 1" // ㅡ,ㅣ : ㅏ,ㅓ,ㅗ,ㅜ : ㅐ,ㅔ
+        static let vowel2: String = "Vowel 2" // ㅑ,ㅕ,ㅛ,ㅠ,ㅒ,ㅖ
+        static let vowel3: String = "Vowel 3" // ㅢ,ㅟ,ㅚ,ㅘ,ㅝ,ㅙ,ㅞ
+        static let vowel4: String = "Vowel 4" // Vowel Quiz
+        
+        static let batchim0: String = "Batchim 0" // Batchim Prologue
+        static let batchim1: String = "Batchim 1" // ㄱ,ㄴ,ㄷ,ㄹ,ㅁ,ㅂ,ㅇ | ㅅ,ㅈ,ㅊ,ㅋ,ㅌ,ㅍ,ㄲ,ㅆ
+        static let batchim2: String = "Batchim 2" // ㅎ | 겹받침
+        static let batchim3: String = "Batchim 3" // Batchim Quiz
+
         
         static let chapters: [String] = [
-            system,
-            consonant1,
-            consonant2,
-            consonant3,
-            consonant4,
-            consonant5,
-            vowel1,
-            vowel2,
-            vowel3
+            system, // 0
+            consonant0, // 1
+            consonant1, // 2
+            consonant2, // 3
+            consonant3, // 4
+            consonant4, // 5
+            consonant5, // 6
+            vowel0, // 7
+            vowel1, // 8
+            vowel2, // 9
+            vowel3, // 10
+            vowel4, // 11
+            batchim0, // 12
+            batchim1, // 13
+            batchim2, // 14
+            batchim3, // 15
         ]
         
         static let chapterComponent: [[[String]]] = [
             [[]],
             [
+                ["Prologue"],
                 ["ㄱ","ㄴ","ㄷ","ㄹ"],
                 ["ㅁ","ㅂ","ㅅ","ㅇ","ㅈ"],
                 ["ㅊ","ㅋ","ㅌ","ㅍ","ㅎ"],
                 ["ㄲ","ㄸ","ㅃ","ㅆ","ㅉ"],
-                []
+                ["Consonant Quiz"]
             ],
             [
+                ["Prologue"],
                 ["ㅡ","ㅣ","ㅏ","ㅓ","ㅗ","ㅜ","ㅐ","ㅔ"],
                 ["ㅑ","ㅕ","ㅛ","ㅠ","ㅒ","ㅖ"],
                 ["ㅢ","ㅚ","ㅟ","ㅘ","ㅝ","ㅙ","ㅞ"],
+                ["Vowel Quiz"]
+            ],
+            [
+                ["Prologue"],
+                ["Basic"],
+                ["Advanced"],
+                ["Batchim Quiz"]
             ]
         ]
     }

--- a/Orum/Orum/Models/HangulUnitEnum.swift
+++ b/Orum/Orum/Models/HangulUnitEnum.swift
@@ -12,6 +12,8 @@ struct HangulUnitEnum: RawRepresentable { // 자모 분리를 통해서 ㄱ -> g
     
     static let system: [HangulCard] = []
     
+    static let consonant0: [HangulCard] = []
+    
     static let consonant1: [HangulCard] = [
         HangulCard(name: "ㄱ"),
         HangulCard(name: "ㄴ"),
@@ -46,14 +48,46 @@ struct HangulUnitEnum: RawRepresentable { // 자모 분리를 통해서 ㄱ -> g
     
     static let consonant5: [HangulCard] = []
     
+    static let vowel0: [HangulCard] = []
+
+    
     static let vowel1: [HangulCard] = [
-        HangulCard(name: "ㄱ"),
-        HangulCard(name: "ㄴ"),
-        HangulCard(name: "ㄷ"),
-        HangulCard(name: "ㄹ"),
+        HangulCard(name: "ㅡ"),
+        HangulCard(name: "ㅣ"),
+        HangulCard(name: "ㅏ"),
+        HangulCard(name: "ㅓ"),
+        HangulCard(name: "ㅗ"),
+        HangulCard(name: "ㅜ"),
+        HangulCard(name: "ㅐ"),
+        HangulCard(name: "ㅔ"),
     ]
     
-    static let vowel2: [HangulCard] = []
+    static let vowel2: [HangulCard] = [
+        HangulCard(name: "ㅑ"),
+        HangulCard(name: "ㅕ"),
+        HangulCard(name: "ㅛ"),
+        HangulCard(name: "ㅠ"),
+        HangulCard(name: "ㅒ"),
+        HangulCard(name: "ㅖ"),
+    ]
     
-    static let vowel3: [HangulCard] = []
+    static let vowel3: [HangulCard] = [
+        HangulCard(name: "ㅢ"),
+        HangulCard(name: "ㅟ"),
+        HangulCard(name: "ㅚ"),
+        HangulCard(name: "ㅘ"),
+        HangulCard(name: "ㅝ"),
+        HangulCard(name: "ㅙ"),
+        HangulCard(name: "ㅞ"),
+    ]
+    
+    static let vowel4: [HangulCard] = []
+    
+    static let batchim0: [HangulCard] = []
+    
+    static let batchim1: [HangulCard] = []
+    
+    static let batchim2: [HangulCard] = []
+    
+    static let batchim3: [HangulCard] = []
 }

--- a/Orum/Orum/OrumApp.swift
+++ b/Orum/Orum/OrumApp.swift
@@ -10,36 +10,40 @@ import SwiftUI
 @main
 struct OrumApp: App {
     @StateObject private var navigationManager = NavigationManager()
+    
     var body: some Scene {
         WindowGroup {
-//            switch navigationManager.viewCycle {
-//            case .first:
-//                TripDateSettingView()
-//                    .environmentObject(navigationManager)
-//                    .transition(.slide)
-//
-//            case .second:
-//                TripRemainingDayView()
-//                    .environmentObject(navigationManager)
-//                    .transition(.slide)
-//
-//            case .third:
-//                FlightInfoSubmitView()
-//                    .environmentObject(navigationManager)
-//                    .transition(.slide)
-//
-//            case .fourth:
-//                DepartRemainingTimeView()
-//                    .environmentObject(navigationManager)
-//                    .transition(.slide)
-//
-//
-//            case .fifth:
-//                HangulEducationMainView()
-//                    .environmentObject(navigationManager)
-//                    .transition(.slide)
-//            }
             FlightMainView()
+            
+            /*
+            switch navigationManager.viewCycle {
+            case .first:
+                TripDateSettingView()
+                    .environmentObject(navigationManager)
+                    .transition(.slide)
+
+            case .second:
+                TripRemainingDayView()
+                    .environmentObject(navigationManager)
+                    .transition(.slide)
+
+            case .third:
+                FlightInfoSubmitView()
+                    .environmentObject(navigationManager)
+                    .transition(.slide)
+
+            case .fourth:
+                DepartRemainingTimeView()
+                    .environmentObject(navigationManager)
+                    .transition(.slide)
+
+
+            case .fifth:
+                HangulEducationMainView()
+                    .environmentObject(navigationManager)
+                    .transition(.slide)
+            }
+             */
         }
     }
 }

--- a/Orum/Orum/ViewModels/EducationManager.swift
+++ b/Orum/Orum/ViewModels/EducationManager.swift
@@ -14,33 +14,45 @@ enum ChapterState: String{
 }
 
 enum ChapterType {
-    case system, consonant, vowel
+    case system, consonant, vowel, batchim
+}
+
+enum lessonType {
+    case prologue, lesson, quiz
 }
 
 class EducationManager: ObservableObject {
     @AppStorage("completedDate") var completedDates: [String:String] = [
         Constants.Chapter.system: "2023.11.04 16:23",
+        Constants.Chapter.vowel1: ""
     ]
     @AppStorage("chapterState") var chapterState: [String:String] = [
         Constants.Chapter.system : "complete",
-        Constants.Chapter.consonant1 : "currentSession", // 현재 가장 최신의 진도
-        Constants.Chapter.consonant2 : "locked",
-        Constants.Chapter.consonant3 : "locked",
-        Constants.Chapter.consonant4 : "locked",
-        Constants.Chapter.consonant5 : "locked",
+        Constants.Chapter.consonant0 : "complete",
+        Constants.Chapter.consonant1 : "complete", // 현재 가장 최신의 진도
+        Constants.Chapter.consonant2 : "complete",
+        Constants.Chapter.consonant3 : "complete",
+        Constants.Chapter.consonant4 : "complete",
+        Constants.Chapter.consonant5 : "complete",
+        Constants.Chapter.vowel0 : "complete",
         Constants.Chapter.vowel1 : "complete",
-        Constants.Chapter.vowel2 : "locked",
-        Constants.Chapter.vowel3 : "locked",
+        Constants.Chapter.vowel2 : "complete",
+        Constants.Chapter.vowel3 : "complete",
+        Constants.Chapter.vowel4 : "complete",
+        Constants.Chapter.batchim0: "complete",
+        Constants.Chapter.batchim1 : "complete",
+        Constants.Chapter.batchim2 : "complete",
+        Constants.Chapter.batchim3 : "currentSession",
     ]
     @AppStorage("wrongCount") var wrongCount: [String:String] = [:]
 
-    @Published var content: [HangulCard] = HangulUnitEnum.consonant1
-    @Published var quiz: [HangulCard] = HangulUnitEnum.consonant1
+    @Published var content: [HangulCard] = HangulUnitEnum.vowel1
+    @Published var quiz: [HangulCard] = HangulUnitEnum.vowel1
     @Published var storage: [HangulCard] = []
-    @Published var nowStudying: String = Constants.Chapter.consonant1 // 현재 공부하고 있는 단원 (진도와는 무관)
-    @Published var chapterType: ChapterType = .consonant
+    @Published var nowStudying: String = Constants.Chapter.vowel1 // 현재 공부하고 있는 단원 (진도와는 무관)
+    @Published var chapterType: ChapterType = .vowel
+    @Published var lessonType: lessonType = .prologue
     @Published var index: Int = 0
-//    @Published var wrongCount: [String : Int] = [:]
     
     init() {
     }
@@ -52,6 +64,11 @@ class EducationManager: ObservableObject {
             quiz = HangulUnitEnum.system
             chapterType = .system
         
+        case Constants.Chapter.consonant0:
+            content = HangulUnitEnum.consonant0
+            quiz = HangulUnitEnum.consonant0
+            chapterType = .consonant
+            
         case Constants.Chapter.consonant1:
             content = HangulUnitEnum.consonant1
             quiz = HangulUnitEnum.consonant1
@@ -79,6 +96,11 @@ class EducationManager: ObservableObject {
             quiz = HangulUnitEnum.consonant5
             chapterType = .consonant
             
+        case Constants.Chapter.vowel0:
+            content = HangulUnitEnum.vowel0
+            quiz = HangulUnitEnum.vowel0
+            chapterType = .vowel
+            
         case Constants.Chapter.vowel1:
             content = HangulUnitEnum.vowel1
             quiz = HangulUnitEnum.vowel1
@@ -93,6 +115,31 @@ class EducationManager: ObservableObject {
             content = HangulUnitEnum.vowel3
             quiz = HangulUnitEnum.vowel3
             chapterType = .vowel
+            
+        case Constants.Chapter.vowel4:
+            content = HangulUnitEnum.vowel4
+            quiz = HangulUnitEnum.vowel4
+            chapterType = .vowel
+         
+        case Constants.Chapter.batchim0:
+            content = HangulUnitEnum.batchim0
+            quiz = HangulUnitEnum.batchim0
+            chapterType = .batchim
+            
+        case Constants.Chapter.batchim1:
+            content = HangulUnitEnum.batchim1
+            quiz = HangulUnitEnum.batchim1
+            chapterType = .batchim
+            
+        case Constants.Chapter.batchim2:
+            content = HangulUnitEnum.batchim2
+            quiz = HangulUnitEnum.batchim2
+            chapterType = .batchim
+            
+        case Constants.Chapter.batchim3:
+            content = HangulUnitEnum.batchim3
+            quiz = HangulUnitEnum.batchim3
+            chapterType = .batchim
             
         default:
             return

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/Components/Category.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/Components/Category.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct Category: View {
     let action: () -> ()
-    let chaptersNum: [Int] = [1, 5, 3]
+    let chaptersNum: [Int] = [1, 6, 5, 4]
     
     @EnvironmentObject var educationManager: EducationManager
     
@@ -20,9 +20,11 @@ struct Category: View {
         case 0:
             "System"
         case 1:
-            "Consonant"
+            "Consonant (Jaeum)"
         case 2:
-            "Vowel"
+            "Vowel (Moeum)"
+        case 3:
+            "Last Consonant (Batchim)"
         default:
             ""
         }

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/Components/Chapter.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/Components/Chapter.swift
@@ -39,11 +39,13 @@ struct Chapter: View {
         
         switch categoryInd {
         case 0:
-            ind = 0
+            ind = 0 // 0
         case 1:
-            ind = 1 + chapterInd
+            ind = 1 + chapterInd // 1,2,3,4,5,6
         case 2:
-            ind = 2 * 3 + chapterInd
+            ind = 7 + chapterInd // 7,8,9,10,11
+        case 3:
+            ind = 12 + chapterInd // 12,13,14,15
         default:
             ind = 0
         }
@@ -52,7 +54,7 @@ struct Chapter: View {
     }
     
     var isButtonLocked: Bool {
-        switch educationManager.chapterState[chapterName]!.toEnum() {
+        switch educationManager.chapterState[chapterName]?.toEnum() ?? .locked {
             case .locked:
             true
         case .complete,.currentSession:
@@ -67,7 +69,7 @@ struct Chapter: View {
             action()
         })
         {
-            switch educationManager.chapterState[chapterName]!.toEnum(){
+            switch educationManager.chapterState[chapterName]?.toEnum() ?? .locked {
             case .locked:
                 VStack {
                     HStack {

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/FlightMainView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/FlightMainView.swift
@@ -11,28 +11,64 @@ struct FlightMainView: View {
     @StateObject var educationManager: EducationManager = EducationManager()
     
     var body: some View {
-        TabView {
-            LearnView()
-                .environmentObject(educationManager)
-                .tabItem {
+        ZStack {
+            TabView {
+                LearnView()
+                    .environmentObject(educationManager)
+                    .tabItem {
                         Label("Learn", systemImage: "book.fill")
-                }
-            
-            GameView()
-                .environmentObject(educationManager)
-                .tabItem {
+                    }
+                
+                GameView()
+                    .environmentObject(educationManager)
+                    .tabItem {
                         Label("Game", systemImage: "gamecontroller")
-                }
-
-            
-            StorageView()
-                .environmentObject(educationManager)
-                .tabItem {
+                    }
+                
+                
+                StorageView()
+                    .environmentObject(educationManager)
+                    .tabItem {
                         Label("Search", systemImage: "list.bullet.rectangle.portrait")
+                    }
+            }
+            /*
+            VStack {
+                Spacer()
+                
+                HStack {
+                    RoundedRectangle(cornerRadius: 4)
+                        .frame(width: 50, height: 30)
+                        .padding(8)
+                    
+                    Text("ㄱㄴㄷㄹ")
+                    
+                    Spacer()
+                    
+                    Image(systemName: "play.fill")
+                        .padding(.trailing, 8)
                 }
+                .background(RoundedRectangle(cornerRadius: 4)
+                    .foregroundStyle(.white))
+                .padding(.horizontal, 16)
+                .padding(.bottom, UITabBarController().height)
+            }
+            */
         }
     }
 }
+
+/*
+extension UITabBarController {
+    var height: CGFloat {
+        return self.tabBar.frame.size.height
+    }
+    
+    var width: CGFloat {
+        return self.tabBar.frame.size.width
+    }
+}
+*/
 
 #Preview {
     FlightMainView()

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/HangulCardView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/HangulCardView.swift
@@ -32,16 +32,19 @@ struct HangulCardView: View {
                             .resizable()
                             .frame(width: isLearningView ? 180 : 130 , height: isLearningView ? 180 : 130)
                         
-                        ZStack{
+                            Text("[ ")
+                                .bold()
+                                .font( isLearningView ? .largeTitle : .title2)
+                                .foregroundColor(Color(uiColor: .systemGray4))
+                            +
                             Text(hangulCard.sound)
                                 .fontWeight(.bold)
                                 .font( isLearningView ? .largeTitle : .title2)
-                            
-                            Text("[   ]")
+                            +
+                            Text(" ]")
                                 .fontWeight(.bold)
                                 .font( isLearningView ? .largeTitle : .title2)
                                 .foregroundColor(Color(uiColor: .systemGray4))
-                        }
                     } else {
                         if educationManager.chapterType == .consonant {
                             LottieView(fileName: hangulCard.name)

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationLearningView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationLearningView.swift
@@ -83,7 +83,6 @@ struct HangulEducationLearningView: View {
                                 .overlay(RoundedRectangle(cornerRadius: 24)
                                     .stroke(isExample2Listened ? Color(uiColor: .systemGray4) : .blue , lineWidth: 11))
                                 .onTapGesture {
-                                    print(isOnceFlipped)
                                     if !isExample2Listened {
                                         touchCardsCount += 1
                                     }
@@ -135,14 +134,29 @@ struct HangulEducationLearningView: View {
             
             Button(action: {
                 if educationManager.index < educationManager.content.count - 1 {
-                    educationManager.index += 1
                     progressValue += 1
                     
                     if educationManager.chapterType == .vowel {
-                        currentEducation = .vowelDrawing
+                        if educationManager.nowStudying == Constants.Chapter.vowel1 && (educationManager.index == 1 || educationManager.index == 5) {
+                            print(educationManager.index)
+                            currentEducation = .basicVowelCheck
+                            return
+                        }
+                        else {
+                            currentEducation = .vowelDrawing
+                        }
                     }
+                    
+                    educationManager.index += 1
                 }
                 else {
+                    if educationManager.chapterType == .vowel {
+                        if educationManager.nowStudying == Constants.Chapter.vowel1 && educationManager.index == 7 {
+                            currentEducation = .basicVowelCheck
+                            return
+                        }
+                    }
+                    
                     isOnceFlipped = false
                     educationManager.index = 0
                     withAnimation(.easeIn(duration: 1)) {
@@ -165,7 +179,7 @@ struct HangulEducationLearningView: View {
             })
             .background((educationManager.index == 0 && isOnceFlipped && isExample1Listened && isExample2Listened) ? .blue.opacity(0.05) : .clear)
             .buttonStyle(.borderedProminent)
-            .disabled((educationManager.chapterType == .consonant && (!isOnceFlipped || !isExample1Listened || !isExample2Listened)) || (educationManager.chapterType == .vowel && !isOnceFlipped))
+//            .disabled((educationManager.chapterType == .consonant && (!isOnceFlipped || !isExample1Listened || !isExample2Listened)) || (educationManager.chapterType == .vowel && !isOnceFlipped))
         }
         .padding(24)
     }

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationRecapView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationRecapView.swift
@@ -86,6 +86,9 @@ struct HangulEducationRecapView: View {
                     case .vowel:
                         progressValue += 1
                         currentEducation = .vowelQuiz
+                    case .batchim:
+                        progressValue += 1
+                        currentEducation = .quiz
                     }
                 } label: {
                     Text("Ready to Quiz")

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/HangulEducationView.swift
@@ -19,33 +19,48 @@ struct HangulEducationView: View {
     
     var body: some View {
         NavigationView {
-            switch currentEducation {
-            case .onboarding:
-                HangulEducationOnboardingView(currentEducation: $currentEducation, progressValue: $progressValue, isPresented: $isPresented)
+            switch educationManager.lessonType {
+            case .prologue:
+                PrologueView(isPresented: $isPresented)
                     .environmentObject(educationManager)
                 
-            case .vowelDrawing:
-                VowelDrawingView(currentEducation: $currentEducation, progressValue: $progressValue, isPresented: $isPresented)
-                    .environmentObject(educationManager)
+            case .lesson:
+                switch currentEducation {
+                case .onboarding:
+                    HangulEducationOnboardingView(currentEducation: $currentEducation, progressValue: $progressValue, isPresented: $isPresented)
+                        .environmentObject(educationManager)
+                    
+                case .vowelDrawing:
+                    VowelDrawingView(currentEducation: $currentEducation, progressValue: $progressValue, isPresented: $isPresented)
+                        .environmentObject(educationManager)
+                    
+                case .learning:
+                    HangulEducationLearningView(progressValue: $progressValue, currentEducation: $currentEducation, isPresented: $isPresented)
+                        .environmentObject(educationManager)
+                        .transition(.opacity)
                 
-            case .learning:
-                HangulEducationLearningView(progressValue: $progressValue, currentEducation: $currentEducation, isPresented: $isPresented)
-                    .environmentObject(educationManager)
-                    .transition(.opacity)
+                case .basicVowelCheck:
+                    BasicVowelCheckView(progressValue: $progressValue, isPresented: $isPresented, currentEducation: $currentEducation)
+                        .environmentObject(educationManager)
+                        .transition(.opacity)
+                    
+                case .recap:
+                    HangulEducationRecapView(progressValue: $progressValue, currentEducation: $currentEducation, isPresented: $isPresented)
+                        .environmentObject(educationManager)
+                    
+                case .vowelQuiz:
+                    SameCardCollectingQuizView(currentEducation: $currentEducation, progressValue: $progressValue)
+                        .environmentObject(educationManager)
+                        .padding(16)
                 
-            case .recap:
-                HangulEducationRecapView(progressValue: $progressValue, currentEducation: $currentEducation, isPresented: $isPresented)
-                    .environmentObject(educationManager)
-                
-            case .vowelQuiz:
-                SameCardCollectingQuizView(currentEducation: $currentEducation, progressValue: $progressValue)
-                    .environmentObject(educationManager)
-                    .padding(16)
-                
+                case .quiz:
+                    HangulEducationQuizView(progressValue: $progressValue, isPresented: $isPresented)
+                        .environmentObject(educationManager)
+                        .transition(.opacity)
+                }
             case .quiz:
-                HangulEducationQuizView(progressValue: $progressValue, isPresented: $isPresented)
+                QuizLessonView(isPresented: $isPresented)
                     .environmentObject(educationManager)
-                    .transition(.opacity)
             }
         }
         .edgesIgnoringSafeArea([.bottom])
@@ -56,6 +71,7 @@ enum CurrentEducation {
     case onboarding
     case vowelDrawing
     case learning
+    case basicVowelCheck
     case recap
     case vowelQuiz
     case quiz

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/LearnView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/LearnView.swift
@@ -19,7 +19,7 @@ struct LearnView: View {
                 Divider()
                 
                 VStack(alignment: .leading,spacing: 16) {
-                    ForEach (0 ..< 3) { ind in
+                    ForEach (0 ..< 4) { ind in
                         Category(action: {
                             isPresented.toggle()
                         }, categoryInd: ind)

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/LearningView/BasicVowelCheckView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/LearningView/BasicVowelCheckView.swift
@@ -1,42 +1,47 @@
 //
-//  HangulEducationOnboardingView.swift
+//  BasicVowelCheckView.swift
 //  Orum
 //
-//  Created by Youngbin Choi on 11/6/23.
+//  Created by 차차 on 11/14/23.
 //
 
 import SwiftUI
 
-struct HangulEducationOnboardingView: View {
-    @Binding var currentEducation: CurrentEducation
+struct BasicVowelCheckView: View {
     @Binding var progressValue: Int
     @Binding var isPresented: Bool
+    @Binding var currentEducation: CurrentEducation
     
     @EnvironmentObject var educationManager: EducationManager
     
+    private var str: String {
+        if educationManager.index == 1 {
+            return " ㅡ,ㅣ "
+        }
+        else if educationManager.index == 5 {
+            return "ㅏ,ㅓ,ㅗ,ㅜ"
+        }
+        else {
+            return "ㅐ,ㅔ"
+        }
+    }
+    
     var body: some View {
         ZStack {
-            ScrollView {
+            ScrollView{
                 VStack {
                     ProgressView(value: Double(progressValue) / Double(educationManager.content.count * 2 + 2))
                         .padding(.vertical, 16)
                     
-        //            Divider()
-                    switch educationManager.chapterType {
-                    case .system:
-                        SystemOnboarding()
+                    HStack{
+                        Text("\(str)")
+                            .font(.largeTitle)
+                            .bold()
                         
-                    case .consonant:
-                        ConsonantOnboarding()
-                        
-                    case .vowel:
-                        VowelOnboarding()
-                        
-                    case .batchim:
-                        BatchimOnboarding()
-                        
-                        
+                        Spacer()
                     }
+                    .padding(.bottom, 24)
+
                 }
                 .padding(.horizontal, 16)
                 .navigationTitle(educationManager.nowStudying)
@@ -45,21 +50,21 @@ struct HangulEducationOnboardingView: View {
                     isPresented.toggle()
                 }, label: {
                     Image(systemName: "xmark.circle.fill")
-                        .font(.title3)
                         .foregroundStyle(.blue, Color(uiColor: .secondarySystemFill))
                         .symbolRenderingMode(.palette)
-            }))
+                }))
             }
             
-            // 버튼 뒷 배경
+            //버튼 뒷배경
             VStack {
                 Spacer()
                 
                 HStack {
                     Button(action: {}, label: {
-                        Text("Continue")
+                        Text("background")
                             .frame(maxWidth: .infinity)
                             .padding(.vertical, 8)
+                            .bold()
                     })
                     .buttonStyle(.borderedProminent)
                     .hidden()
@@ -71,35 +76,32 @@ struct HangulEducationOnboardingView: View {
             VStack {
                 Spacer()
                 
-                Button(action: {
-                    switch educationManager.chapterType {
-                    case .system:
-                        isPresented.toggle()
-                    case .consonant:
-                        currentEducation = .learning
+                Button {
+                    if educationManager.index < 7 {
                         progressValue += 1
-                    case .vowel:
+                        educationManager.index += 1
                         currentEducation = .vowelDrawing
-                        progressValue += 1
-                    case .batchim:
-                        currentEducation = .learning
-                        progressValue += 1
                     }
-                }, label: {
-                    Text("Continue")
+                    else {
+                        progressValue += 1
+                        currentEducation = .recap
+                    }
+                } label: {
+                    Text("Next")
                         .frame(maxWidth: .infinity)
                         .padding(.vertical, 8)
                         .bold()
-                })
+                }
                 .buttonStyle(.borderedProminent)
-                .padding(.horizontal, 24)
-                .padding(.bottom, 24)
-            }
+                .padding(24)
+                .background(
+                    LinearGradient(gradient: Gradient(colors: [Color(uiColor: .systemBackground).opacity(0.0), Color(uiColor: .systemBackground).opacity(1.0)]), startPoint: .top, endPoint: .bottom)
+                )}
         }
     }
 }
 
 #Preview {
-    HangulEducationOnboardingView(currentEducation: .constant(.onboarding), progressValue: .constant(0),isPresented: .constant(false))
+    BasicVowelCheckView(progressValue: .constant(0), isPresented: .constant(true), currentEducation: .constant(.recap))
         .environmentObject(EducationManager())
 }

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/LearningView/ConsonantLearningView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/LearningView/ConsonantLearningView.swift
@@ -231,6 +231,8 @@ struct ConsonantLearningView: View {
             .background(
                 correctionBackground()
             )
+        case .basicVowelCheck:
+            Spacer()
         }
     }
     

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/LearningView/VowelDrawingView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/LearningView/VowelDrawingView.swift
@@ -65,7 +65,7 @@ struct VowelDrawingView: View {
                     .buttonStyle(.borderedProminent)
                     .padding(.horizontal, 24)
 //                    .padding(.bottom, 24)
-                    .disabled(writingCount < 3)
+//                    .disabled(writingCount < 3)
                 }
             }
         }

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/OnboardingView/BatchimOnboarding.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/OnboardingView/BatchimOnboarding.swift
@@ -1,0 +1,19 @@
+//
+//  BatchimOnboarding.swift
+//  Orum
+//
+//  Created by 차차 on 11/14/23.
+//
+
+import SwiftUI
+
+struct BatchimOnboarding: View {
+    
+    var body: some View {
+            Text("ABC")
+    }
+}
+
+#Preview {
+    BatchimOnboarding()
+}

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/OnboardingView/VowelOnboarding.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/OnboardingView/VowelOnboarding.swift
@@ -7,81 +7,9 @@
 
 import SwiftUI
 
-struct CustomLineShapeWithAlignment: Shape {
-    
-    let stratPoint: Alignment
-    let endPoint: Alignment
-    
-    init(stratPoint: Alignment, endPoint: Alignment) {
-        self.stratPoint = stratPoint
-        self.endPoint = endPoint
-    }
-    
-    private func cgPointTranslator(alignment: Alignment, rect: CGRect) -> CGPoint {
-        
-        switch alignment {
-        case .topLeading: 
-            return CGPoint(x: rect.minX, y: rect.minY)
-        
-        case .top:
-            return CGPoint(x: rect.midX, y: rect.minY)
-        
-        case .topTrailing:
-            return CGPoint(x: rect.maxX, y: rect.minY)
-            
-        case .leading: 
-            return CGPoint(x: rect.minX, y: rect.midY)
-        
-        case .center:
-            return CGPoint(x: rect.midX, y: rect.midY)
-        
-        case .trailing:
-            return CGPoint(x: rect.maxX, y: rect.midY)
-            
-        case .bottomLeading: 
-            return CGPoint(x: rect.minX, y: rect.maxY)
-        
-        case .bottom:
-            return CGPoint(x: rect.midX, y: rect.maxY)
-        
-        case .bottomTrailing:
-            return CGPoint(x: rect.maxX, y: rect.maxY)
-        
-        default:
-            return CGPoint(x: rect.minX, y: rect.minY)
-        }
-        
-    }
-
-    func path(in rect: CGRect) -> Path {
-        
-        Path { path in
-            
-            path.move(to: cgPointTranslator(alignment: stratPoint, rect: rect))
-            path.addLine(to: cgPointTranslator(alignment: endPoint, rect: rect))
-            
-        }
-        
-    }
-    
-}
-
-
 struct VowelOnboarding: View {
-    @State private var isPressed = false
-    
     var body: some View {
-        ZStack {
-                    
-                    CustomLineShapeWithAlignment(stratPoint: .topLeading, endPoint: .bottomLeading)
-                        .stroke(style: StrokeStyle(lineWidth: 1.0, dash: [5]))
-                        .frame(width: 1.0)
-                    
-                    CustomLineShapeWithAlignment(stratPoint: .leading, endPoint: .trailing)
-                        .stroke(style: StrokeStyle(lineWidth: 1.0, dash: [5]))
-                        .frame(height: 1.0)
-                    
-                }
+        Text("VowelOnboarding")
     }
 }
 

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/PrologueView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/PrologueView.swift
@@ -1,0 +1,20 @@
+//
+//  PrologueView.swift
+//  Orum
+//
+//  Created by 차차 on 11/14/23.
+//
+
+import SwiftUI
+
+struct PrologueView: View {
+    @Binding var isPresented: Bool
+    
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    PrologueView(isPresented: .constant(false))
+}

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/QuizLessonView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/QuizLessonView.swift
@@ -1,0 +1,20 @@
+//
+//  QuizLessonView.swift
+//  Orum
+//
+//  Created by 차차 on 11/14/23.
+//
+
+import SwiftUI
+
+struct QuizLessonView: View {
+    @Binding var isPresented: Bool
+    
+    var body: some View {
+        Text(/*@START_MENU_TOKEN@*/"Hello, World!"/*@END_MENU_TOKEN@*/)
+    }
+}
+
+#Preview {
+    QuizLessonView(isPresented: .constant(false))
+}

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/SameCardCollectingQuizView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/SameCardCollectingQuizView.swift
@@ -23,12 +23,12 @@ struct SameCardCollectingQuizView: View {
     @EnvironmentObject var educationManager: EducationManager
     
     var body: some View {
-        ProgressView(value: Double(progressValue) / Double(educationManager.content.count * 2 + 2))
-            .padding(.vertical, 16)
-
         ZStack{
             ScrollView{
                 VStack(alignment: .leading ,  spacing: 32){
+                    ProgressView(value: Double(progressValue) / Double(educationManager.content.count * 2 + 2))
+                        .padding(.vertical, 16)
+                    
                     Text("Select appropriate vowel of the sound")
                         .font(.title2)
                         .fontWeight(.bold)

--- a/Orum/Orum/Views/DuringFlight/ver 1.1/StorageView.swift
+++ b/Orum/Orum/Views/DuringFlight/ver 1.1/StorageView.swift
@@ -22,7 +22,7 @@ struct StorageView: View {
         NavigationStack {
             ScrollView {
                 VStack(alignment: .leading, spacing: 16) {
-                    
+                    /*
                     ZStack {
                         if isCanvasOpened {
                             VStack {
@@ -102,6 +102,7 @@ struct StorageView: View {
                             }
                         }
                     }
+                    */
                     
                     Button(action: {
                         chapterName = "Consonant"


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->
- 모음 교육의 이동 로직을 구현했습니다.
- 작업 이슈: #83 

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->
- 기본 모음 (ㅡ,ㅣ,ㅏ,ㅓ,ㅗ,ㅜ,ㅐ,ㅔ) 2 / 4 / 2로 나눈 BasicVowelCheckView 생성
- 위에 맞는 화면 이동 로직 구현

## Logic
<!-- 작업 내용 1 -->
```swift
struct BasicVowelCheckView: View {
    @Binding var progressValue: Int
    @Binding var isPresented: Bool
    @Binding var currentEducation: CurrentEducation
    
    @EnvironmentObject var educationManager: EducationManager
    
    private var str: String {
        if educationManager.index == 1 {
            return " ㅡ,ㅣ "
        }
        else if educationManager.index == 5 {
            return "ㅏ,ㅓ,ㅗ,ㅜ"
        }
        else {
            return "ㅐ,ㅔ"
        }
    }
```
index를 통해 ㅡ,ㅣ / ㅏ,ㅓ,ㅗ,ㅜ / ㅐ,ㅔ 를 구별하고 각각이 끝날 때 서로 비교해볼 수 있는 화면을 구현하였습니다.

 ## 작업 결과(이미지 첨부는 선택)
<img width="525" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team3-BluePeriodClub/assets/58865827/88ea8e81-989a-4f5c-9831-931559802f4e">

