### PR TITLE
[Feat/#92] Add OnboardingView

### DIFF
--- a/Orum/Orum.xcodeproj/project.pbxproj
+++ b/Orum/Orum.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		93DA78EF2AFB6233004BB43F /* VowelDrawingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93DA78EE2AFB6233004BB43F /* VowelDrawingView.swift */; };
 		93DA78F12AFB6912004BB43F /* SameCardCollectingQuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93DA78F02AFB6912004BB43F /* SameCardCollectingQuizView.swift */; };
 		93DA78F42AFB6B35004BB43F /* ConsonantOnboarding.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93DA78F32AFB6B35004BB43F /* ConsonantOnboarding.swift */; };
+		93EF74AC2B04DA08003111CD /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93EF74AB2B04DA08003111CD /* OnboardingView.swift */; };
 		D9037CE72AF0C4270098DB57 /* HangulEducationLearningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9037CE62AF0C4260098DB57 /* HangulEducationLearningView.swift */; };
 		D9037CE92AF0C55A0098DB57 /* HangulEducationQuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9037CE82AF0C55A0098DB57 /* HangulEducationQuizView.swift */; };
 		D9037D092AF0D2B70098DB57 /* HangulCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9037D082AF0D2B70098DB57 /* HangulCardView.swift */; };
@@ -96,6 +97,7 @@
 		93DA78EE2AFB6233004BB43F /* VowelDrawingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = VowelDrawingView.swift; sourceTree = "<group>"; };
 		93DA78F02AFB6912004BB43F /* SameCardCollectingQuizView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SameCardCollectingQuizView.swift; sourceTree = "<group>"; };
 		93DA78F32AFB6B35004BB43F /* ConsonantOnboarding.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ConsonantOnboarding.swift; sourceTree = "<group>"; };
+		93EF74AB2B04DA08003111CD /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		D9037CE62AF0C4260098DB57 /* HangulEducationLearningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulEducationLearningView.swift; sourceTree = "<group>"; };
 		D9037CE82AF0C55A0098DB57 /* HangulEducationQuizView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulEducationQuizView.swift; sourceTree = "<group>"; };
 		D9037D082AF0D2B70098DB57 /* HangulCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulCardView.swift; sourceTree = "<group>"; };
@@ -184,6 +186,7 @@
 				934912A22B04A00000AF7813 /* ContentView.swift */,
 				93194FD62AF8B8DC002C1BE4 /* Components */,
 				936BDEFF2B04B04500A609B8 /* Tabs */,
+				93EF74AB2B04DA08003111CD /* OnboardingView.swift */,
 			);
 			path = Views;
 			sourceTree = "<group>";
@@ -496,6 +499,7 @@
 				936BDEF22B04A53400A609B8 /* CollectionDetailView.swift in Sources */,
 				936BDEF02B04A48700A609B8 /* CollectionView.swift in Sources */,
 				93194FD52AF8B8D8002C1BE4 /* Lesson.swift in Sources */,
+				93EF74AC2B04DA08003111CD /* OnboardingView.swift in Sources */,
 				D96BAC6A2AE6C37800613540 /* LottieView.swift in Sources */,
 				9336E20A2AF7B505000B9E76 /* Constants.swift in Sources */,
 				93DA78EF2AFB6233004BB43F /* VowelDrawingView.swift in Sources */,

--- a/Orum/Orum/OrumApp.swift
+++ b/Orum/Orum/OrumApp.swift
@@ -9,9 +9,16 @@ import SwiftUI
 
 @main
 struct OrumApp: App {
+    @AppStorage("isFirstLaunching") var isFirstLaunching: Bool = true
+    
     var body: some Scene {
         WindowGroup {
-            ContentView()
+            if isFirstLaunching {
+                OnboardingView(isFirstLaunching: $isFirstLaunching)
+            }
+            else {
+                ContentView()
+            }
         }
     }
 }

--- a/Orum/Orum/Views/OnboardingView.swift
+++ b/Orum/Orum/Views/OnboardingView.swift
@@ -1,0 +1,38 @@
+//
+//  OnboardingView.swift
+//  Orum
+//
+//  Created by 차차 on 11/15/23.
+//
+
+import SwiftUI
+
+struct OnboardingView: View {
+    @Binding var isFirstLaunching: Bool
+    
+    var body: some View {
+        VStack(spacing: 45) {
+            Rectangle()
+                .padding(.horizontal, 16)
+                .padding(.top, 80)
+            
+            Text("Title")
+                .bold()
+                .font(.title)
+            
+            Text("내용")
+            
+            Button(action: {
+                isFirstLaunching.toggle()
+            }, label: {
+                Text("Let's Orum!")
+            })
+            .buttonStyle(.borderedProminent)
+            
+        }
+    }
+}
+
+#Preview {
+    OnboardingView(isFirstLaunching: .constant(false))
+}


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->
- 온보딩 뷰 구조를 구현했습니다.
- 작업 이슈: #92 

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->
- 온보딩 뷰 구조 구현

## Logic
<!-- 작업 내용 1 -->
```swift
import SwiftUI

struct OnboardingView: View {
    @Binding var isFirstLaunching: Bool
    
    var body: some View {
        VStack(spacing: 45) {
            Rectangle()
                .padding(.horizontal, 16)
                .padding(.top, 80)
            
            Text("Title")
                .bold()
                .font(.title)
            
            Text("내용")
            
            Button(action: {
                isFirstLaunching.toggle()
            }, label: {
                Text("Let's Orum!")
            })
            .buttonStyle(.borderedProminent)
            
        }
    }
}

#Preview {
    OnboardingView(isFirstLaunching: .constant(false))
}
```
온보딩 뷰의 구조를 구현했습니다.

```swift
import SwiftUI

@main
struct OrumApp: App {
    @AppStorage("isFirstLaunching") var isFirstLaunching: Bool = true
    
    var body: some Scene {
        WindowGroup {
            if isFirstLaunching {
                OnboardingView(isFirstLaunching: $isFirstLaunching)
            }
            else {
                ContentView()
            }
        }
    }
}
```
AppStorage 변수를 통해 앱의 첫 구동에서만 온보딩 뷰가 실행되도록 했습니다.

 ## 작업 결과(이미지 첨부는 선택)
<img width="520" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team3-BluePeriodClub/assets/58865827/582aac29-8327-4552-b686-8989c821e764">
