### PR TITLE
[Feat/#104] HangulCardView 를 업그레이드 하였습니다

### DIFF
--- a/Orum/Orum/Models/HangulCard.swift
+++ b/Orum/Orum/Models/HangulCard.swift
@@ -6,6 +6,7 @@
 //
 
 import Foundation
+import SwiftUI
 
 struct HangulCard: Hashable {
     let name : String
@@ -15,6 +16,9 @@ struct HangulCard: Hashable {
     var soundExample1 : String = ""
     var soundExample2 : String = ""
     var lottieName : String = ""
+    var explanation : String = ""
+    var chapterType : ChapterType = .system
+    var hangulType : HangulType = .single
     
     init(name: String) {
         self.name = name
@@ -26,15 +30,160 @@ struct HangulCard: Hashable {
             self.soundExample1 = Constants.Hangul.consonantExamples[name]?[0] ?? ""
             self.soundExample2 = Constants.Hangul.consonantExamples[name]?[1] ?? ""
             self.lottieName = Constants.Hangul.lottieName[name] ?? ""
+            self.chapterType = .consonant
+            if Constants.Hangul.lottieName[name] == "" {
+                hangulType = .double
+                self.explanation = Constants.Hangul.consonantCombination[name] ?? ""
+            }
         }
         
         else if Constants.Hangul.vowels.contains(name) {
             self.sound = Constants.Hangul.vowelSound[name] ?? ""
             self.lottieName = ""
+            self.chapterType = .vowel
+            if Constants.Hangul.vowelSimilarSound[name] == "" {
+                hangulType = .double
+                self.explanation = Constants.Hangul.vowelCombination[name] ?? ""
+            } else {
+                hangulType = .single
+                self.explanation = Constants.Hangul.vowelSimilarSound[name] ?? ""
+            }
         }
         
         else { // 받침
             self.sound = Constants.Hangul.consonantSound[name] ?? ""
+            self.chapterType = .batchim
         }
     }
 }
+enum HangulType {
+    case single, double
+}
+
+enum CardType {
+    case small, medium, large
+}
+
+extension CardType {
+    
+    var imageFrame : CGFloat {
+        switch self {
+        case .small:
+            return 48
+        case .medium:
+            return 130
+        case .large:
+            return 180
+        }
+    }
+    
+    var maxHeight : CGFloat {
+        switch self {
+        case .small:
+            return 72
+        case .medium:
+            return 170
+        case .large:
+            return 237
+        }
+    }
+    
+    var imageMeaningSpacing : CGFloat {
+        switch self {
+        case .small:
+            return 3
+        case .medium:
+            return 12
+        case .large:
+            return 16
+        }
+    }
+    
+    var borderWidth : CGFloat {
+        switch self {
+        case .small:
+            return 6
+        case .medium:
+            return 11
+        case .large:
+            return 11
+        }
+    }
+    
+    var paddingTop : CGFloat {
+        switch self {
+        case .small:
+            return 23
+        case .medium:
+            return 36
+        case .large:
+            return 50
+        }
+    }
+    
+    var paddingBottom : CGFloat {
+        switch self {
+        case .small:
+            return 13
+        case .medium:
+            return 30
+        case .large:
+            return 40
+        }
+    }
+    
+    var font : Font {
+        switch self {
+        case .small:
+            return .body
+        case .medium:
+            return .title2
+        case .large:
+            return .largeTitle
+        }
+    }
+    
+    var cornerRadius : CGFloat {
+        switch self {
+        case .small:
+            return 12
+        case .medium:
+            return 24
+        case .large:
+            return 24
+        }
+    }
+    
+    func explanationFont( _ chapterType : ChapterType) -> Font {
+        switch self {
+        case .small:
+            if chapterType == .consonant {
+                return .body
+            } else if chapterType == .vowel {
+                return .footnote
+            } else {
+                return .footnote
+            }
+        case .medium:
+            if chapterType == .consonant {
+                return .title2
+            } else if chapterType == .vowel {
+                return .body
+            } else {
+                return .body
+            }
+        case .large:
+            if chapterType == .consonant {
+                return .largeTitle
+            } else if chapterType == .vowel {
+                return .title2
+            } else {
+                return .title2
+            }
+            
+        }
+    }
+}
+
+
+

--- a/Orum/Orum/Utilities/Constants.swift
+++ b/Orum/Orum/Utilities/Constants.swift
@@ -195,12 +195,25 @@ struct Constants {
             "ㅂ" : "bucket",
             "ㅅ" : "squid",
             "ㅇ" : "nothing",
-            "ㅈ" : "",
-            "ㅊ" : "",
+            "ㅈ" : "jump",
+            "ㅊ" : "champion",
             "ㅋ" : "key",
             "ㅌ" : "tooth",
             "ㅍ" : "pillar",
             "ㅎ" : "hat",
+            "ㄲ" : "",
+            "ㄸ" : "",
+            "ㅃ" : "",
+            "ㅆ" : "",
+            "ㅉ" : "",
+        ]
+        
+        static let consonantCombination : [String: String] = [
+            "ㄲ" : "Pronounce two ㄱ[g] sounds simultaneously",
+            "ㄸ" : "Pronounce two ㄷ[d] sounds simultaneously",
+            "ㅃ" : "Pronounce two ㅂ[b] sounds simultaneously",
+            "ㅆ" : "Pronounce two ㅅ[s] sounds simultaneously",
+            "ㅉ" : "Pronounce two ㅈ[j] sounds simultaneously",
         ]
         
         static let vowels: [String] = [
@@ -249,6 +262,54 @@ struct Constants {
             "ㅝ" : "wue",
             "ㅙ" : "wea",
             "ㅞ" : "wea",
+        ]
+        
+        static let vowelSimilarSound : [String : String] = [
+            "ㅡ" : "Neutral",
+            "ㅣ" : "Tree",
+            "ㅏ" : "Analog",
+            "ㅓ" : "Seoul",
+            "ㅗ" : "Orange",
+            "ㅜ" : "Uber",
+            "ㅐ" : "Aesthetic",
+            "ㅔ" : "Aesthetic",
+            "ㅑ" : "",
+            "ㅕ" : "",
+            "ㅛ" : "",
+            "ㅠ" : "",
+            "ㅒ" : "",
+            "ㅖ" : "",
+            "ㅢ" : "",
+            "ㅟ" : "",
+            "ㅚ" : "",
+            "ㅘ" : "",
+            "ㅝ" : "",
+            "ㅙ" : "",
+            "ㅞ" : "",
+        ]
+        
+        static let vowelCombination : [String : String] = [
+            "ㅡ" : "",
+            "ㅣ" : "",
+            "ㅏ" : "",
+            "ㅓ" : "",
+            "ㅗ" : "",
+            "ㅜ" : "",
+            "ㅐ" : "",
+            "ㅔ" : "",
+            "ㅑ" : "ㅣ[ee] + ㅏ[a]",
+            "ㅕ" : "ㅣ[ee] + ㅓ[eo]",
+            "ㅛ" : "ㅣ[ee] + ㅗ[o]",
+            "ㅠ" : "ㅣ[ee] + ㅜ[u]",
+            "ㅒ" : "ㅣ[ee] + ㅐ[ae]",
+            "ㅖ" : "ㅣ[ee] + ㅔ[ae]",
+            "ㅢ" : "ㅡ[eu] + ㅣ[ee]",
+            "ㅟ" : "ㅗ[o] + ㅣ[ee]",
+            "ㅚ" : "ㅗ[o] + ㅏ[a]",
+            "ㅘ" : "ㅗ[o] + ㅐ[ae]",
+            "ㅝ" : "ㅜ[u] + ㅣ[ee]",
+            "ㅙ" : "ㅜ[u] + ㅓ[eo]",
+            "ㅞ" : "ㅜ[u] + ㅔ[ae]",
         ]
         
         static let vowelQuiz: [String : [String]] = [

--- a/Orum/Orum/ViewModels/EducationManager.swift
+++ b/Orum/Orum/ViewModels/EducationManager.swift
@@ -46,10 +46,10 @@ class EducationManager: ObservableObject {
     ]
     @AppStorage("wrongCount") var wrongCount: [String:String] = [:]
 
-    @Published var content: [HangulCard] = HangulUnitEnum.vowel1
+    @Published var content: [HangulCard] = HangulUnitEnum.consonant1
     @Published var quiz: [HangulQuiz] = HangulUnitQuizEnum.consonant1
     @Published var storage: [HangulCard] = []
-    @Published var nowStudying: String = Constants.Lesson.vowel1 // 현재 공부하고 있는 단원 (진도와는 무관)
+    @Published var nowStudying: String = Constants.Lesson.consonant1 // 현재 공부하고 있는 단원 (진도와는 무관)
     @Published var chapterType: ChapterType = .vowel
     @Published var lessonType: LessonType = .lesson
 

--- a/Orum/Orum/Views/Components/HangulCardView.swift
+++ b/Orum/Orum/Views/Components/HangulCardView.swift
@@ -7,10 +7,6 @@
 
 import SwiftUI
 
-enum ViewType {
-    case learningView, recapView
-}
-
 struct HangulCardView: View {
     @EnvironmentObject var educationManager: EducationManager
     var onTapGesture: () -> Void
@@ -18,7 +14,7 @@ struct HangulCardView: View {
     @State var isFlipped: Bool = false
     @State var isOnceFlipped: Bool = false
     
-    var isLearningView: Bool
+    var cardType: CardType
     
     var body: some View {
         ZStack{
@@ -26,86 +22,153 @@ struct HangulCardView: View {
                 
                 Spacer()
                 
-                VStack(spacing: 16){
+                VStack(spacing: cardType.imageMeaningSpacing){
                     if !isFlipped {
                         Image(hangulCard.name)
                             .resizable()
-                            .frame(width: isLearningView ? 180 : 130 , height: isLearningView ? 180 : 130)
+                            .frame(width: cardType.imageFrame, height: cardType.imageFrame)
+//                            .border(.red)
                         
-                            Text("[ ")
-                                .bold()
-                                .font( isLearningView ? .largeTitle : .title2)
-                                .foregroundColor(Color(uiColor: .systemGray4))
-                            +
-                            Text(hangulCard.sound)
-                                .fontWeight(.bold)
-                                .font( isLearningView ? .largeTitle : .title2)
-                            +
-                            Text(" ]")
-                                .fontWeight(.bold)
-                                .font( isLearningView ? .largeTitle : .title2)
-                                .foregroundColor(Color(uiColor: .systemGray4))
+                        Text("[ ")
+                            .bold()
+                            .font( cardType.font)
+                            .foregroundColor(Color(uiColor: .systemGray4))
+                        +
+                        Text(hangulCard.sound)
+                            .fontWeight(.bold)
+                            .font(cardType.font)
+                        +
+                        Text(" ]")
+                            .fontWeight(.bold)
+                            .font( cardType.font )
+                            .foregroundColor(Color(uiColor: .systemGray4))
+                        
                     } else {
-                        if educationManager.chapterType == .consonant {
-                            LottieView(fileName: hangulCard.name)
-                                .frame(width: isLearningView ? 180 : 130 , height: isLearningView ? 180 : 130)
+                        if hangulCard.chapterType == .consonant {
+                            if hangulCard.hangulType == .single {
+                                LottieView(fileName: hangulCard.name)
+                                    .frame(width: cardType.imageFrame, height: cardType.imageFrame)
+                                    .scaleEffect(x: -1, y: 1)
+                                HStack {
+                                    Spacer()
+                                    
+                                    Text("[")
+                                        .fontWeight(.bold)
+                                        .font(cardType.explanationFont(.consonant))
+                                        .foregroundColor(Color(uiColor: .systemGray4))
+                                    +
+                                    Text(hangulCard.lottieName.prefix(1))
+                                        .fontWeight(.bold)
+                                        .font(cardType.explanationFont(.consonant))
+                                    +
+                                    Text(hangulCard.lottieName.dropFirst(1))
+                                        .fontWeight(.bold)
+                                        .font(cardType.explanationFont(.consonant))
+                                        .foregroundColor(Color(uiColor: .systemGray4))
+                                    +
+                                    Text("]")
+                                        .fontWeight(.bold)
+                                        .font(cardType.explanationFont(.consonant))
+                                        .foregroundColor(Color(uiColor: .systemGray4))
+                                    
+                                    Spacer()
+                                }
                                 .scaleEffect(x: -1, y: 1)
-                            HStack {
-                                Spacer()
-                                
-                                Text("[")
-                                    .fontWeight(.bold)
-                                    .font( isLearningView ? .largeTitle : .title2)
-                                    .foregroundColor(Color(uiColor: .systemGray4))
-                                +
-                                Text(hangulCard.lottieName)
-                                    .fontWeight(.bold)
-                                    .font( isLearningView ? .largeTitle : .title2)
-                                +
-                                Text("]")
-                                    .fontWeight(.bold)
-                                    .font( isLearningView ? .largeTitle : .title2)
-                                    .foregroundColor(Color(uiColor: .systemGray4))
-                                
-                                Spacer()
+                            } else {
+                                Rectangle()
+                                    .foregroundStyle(.clear)
+    //                                .border(.black)
+                                    .frame(maxWidth: cardType.imageFrame, maxHeight: cardType.imageFrame )
+                                    .scaleEffect(x: -1, y: 1)
+                                HStack{
+                                    Text(hangulCard.explanation)
+                                        .bold()
+                                        .font( cardType.explanationFont(.vowel))
+                                }
+                                .frame(width: cardType.imageFrame)
+                                .scaleEffect(x: -1, y: 1)
+                                .multilineTextAlignment(.center)
                             }
-                            .scaleEffect(x: -1, y: 1)
                         }
                         
-                        else {
+                        else if hangulCard.chapterType == .vowel  {
+                            Rectangle()
+                                .foregroundStyle(.clear)
+//                                .border(.black)
+                                .frame(maxWidth: cardType.imageFrame, maxHeight: cardType.imageFrame )
+                                .scaleEffect(x: -1, y: 1)
+                            HStack{
+                                if hangulCard.hangulType == .single {
+                                    Text(hangulCard.name)
+                                        .bold()
+                                        .font( cardType.explanationFont(.vowel))
+                                        .foregroundColor(.blue)
+                                    +
+                                    Text(" is pronunce like ")
+                                        .bold()
+                                        .font( cardType.explanationFont(.vowel))
+                                    +
+                                    Text("[")
+                                        .bold()
+                                        .font( cardType.explanationFont(.vowel))
+                                        .foregroundColor(Color(uiColor: .systemGray4))
+                                    +
+                                    Text(hangulCard.sound)
+                                        .bold()
+                                        .font( cardType.explanationFont(.vowel))
+                                    +
+                                    Text("]")
+                                        .bold()
+                                        .font( cardType.explanationFont(.vowel))
+                                        .foregroundColor(Color(uiColor: .systemGray4))
+                                    +
+                                    Text(" in \(hangulCard.explanation)")
+                                        .bold()
+                                        .font( cardType.explanationFont(.vowel))
+                                } else {
+                                    Text("Pronounce as \(hangulCard.explanation) simultaneously")
+                                        .bold()
+                                        .font( cardType.explanationFont(.vowel))
+                                }
+                            }
+                            .frame(width: cardType.imageFrame)
+                            .scaleEffect(x: -1, y: 1)
+                            .multilineTextAlignment(.center)
+                            
+                        } else {
                             Rectangle()
                                 .foregroundStyle(.clear)
                                 .border(.black)
-                                .frame(width: isLearningView ? 180 : 130 , height: isLearningView ? 180 : 130)
+                                .frame(width: cardType.imageFrame , height: cardType.imageFrame)
                                 .scaleEffect(x: -1, y: 1)
                             
                             Text("[]")
                                 .bold()
-                                .font( isLearningView ? .largeTitle : .title2)
+                                .font(cardType.explanationFont(.batchim))
                                 .scaleEffect(x: -1, y: 1)
                         }
                         
                     }
                 }
-                .padding(EdgeInsets(top: isLearningView ? 50 : 20 , leading: 0, bottom: isLearningView ? 40 : 20, trailing: 0))
+                .frame(minHeight : cardType.maxHeight, maxHeight: cardType.maxHeight)
+                .padding(EdgeInsets(top: cardType.paddingTop , leading: 0, bottom: cardType.paddingBottom, trailing: 0))
                 
                 Spacer()
             }
         }
-        .overlay(RoundedRectangle(cornerRadius: 24)
-            .stroke(isOnceFlipped ? Color(uiColor: .systemGray4) : .blue , lineWidth: 11))
+        .overlay(RoundedRectangle(cornerRadius: cardType.cornerRadius)
+            .strokeBorder(isOnceFlipped ? Color(uiColor: .systemGray4) : .blue , lineWidth: cardType.borderWidth))
         .rotation3DEffect(isFlipped ? Angle(degrees: 180) : .zero,
                           axis: (x: 0.0, y: 1.0, z: 0.0))
         .animation(.easeInOut(duration: 0.5), value: isFlipped)
+        .contentShape(Rectangle())
         .gesture(
             TapGesture()
                 .onEnded {
-                    if !isOnceFlipped && isLearningView {
-                            isOnceFlipped = true
+                    if !isOnceFlipped && cardType != .small {
+                        isOnceFlipped = true
                     }
-                    
                     isFlipped.toggle()
-                    
                     self.onTapGesture()
                 }
         )
@@ -119,6 +182,6 @@ struct HangulCardView: View {
 }
 
 #Preview {
-    HangulCardView(onTapGesture: {},hangulCard: HangulUnitEnum.consonant1[1], isLearningView: false)
+    HangulCardView(onTapGesture: {},hangulCard: HangulUnitEnum.vowel1[0], cardType: .large)
         .environmentObject(EducationManager())
 }

--- a/Orum/Orum/Views/Components/HangulQuizView.swift
+++ b/Orum/Orum/Views/Components/HangulQuizView.swift
@@ -39,15 +39,17 @@ struct HangulQuizView: View {
                             .padding(.vertical, 16)
                             .id(topID)
                         
-                        HStack {
-                            Text("Select appropriate pronunciation of underlined letter")
+                        VStack {
+                            Text("Quiz")
+                                .font(.body)
+                                .fontWeight(.bold)
+                                .foregroundStyle(.secondary)
+                            
+                            Text("Select the corect pronunciation")
                                 .font(.largeTitle)
                                 .fontWeight(.bold)
-                            
-                            Spacer()
+                                .multilineTextAlignment(.center)
                         }
-                        .padding(.bottom, 16)
-                        
                         VStack {
                             HStack{
                                 Spacer()
@@ -390,7 +392,6 @@ struct HangulQuizView: View {
             Color.clear
         }
     }
-    
 }
 
 struct OptionColor {

--- a/Orum/Orum/Views/Tabs/Collection/CollectionDetailView.swift
+++ b/Orum/Orum/Views/Tabs/Collection/CollectionDetailView.swift
@@ -16,16 +16,16 @@ struct CollectionDetailView: View {
             ScrollView {
                 VStack {
                     if chapterName == "Consonant" {
-                        LazyVGrid(columns: [GridItem(.flexible(), spacing: 15), GridItem(.flexible())],spacing: 16) {
+                        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())],spacing: 16) {
                             ForEach(0 ..< 14) { index in
-                                HangulCardView(onTapGesture: {}, hangulCard: HangulCard(name: Constants.Hangul.consonants[index]), isLearningView: false)
+                                HangulCardView(onTapGesture: {}, hangulCard: HangulCard(name: Constants.Hangul.consonants[index]), cardType: .small)
                             }
                         }
                     }
                     else {
-                        LazyVGrid(columns: [GridItem(.flexible(), spacing: 15), GridItem(.flexible())],spacing: 16) {
+                        LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())],spacing: 16) {
                             ForEach(0 ..< 21) { index in
-                                HangulCardView(onTapGesture: {}, hangulCard: HangulCard(name: Constants.Hangul.vowels[index]), isLearningView: false)
+                                HangulCardView(onTapGesture: {}, hangulCard: HangulCard(name: Constants.Hangul.vowels[index]), cardType: .small)
                             }
                         }
                     }
@@ -40,6 +40,6 @@ struct CollectionDetailView: View {
 }
 
 #Preview {
-    CollectionDetailView(chapterName: .constant("Vowel"))
+    CollectionDetailView(chapterName: .constant("Consonant"))
         .environmentObject(EducationManager())
 }

--- a/Orum/Orum/Views/Tabs/Collection/CollectionView.swift
+++ b/Orum/Orum/Views/Tabs/Collection/CollectionView.swift
@@ -89,10 +89,10 @@ struct CollectionView: View {
                         .bold()
                         .font(.title2)
                     
-                    LazyVGrid(columns: [GridItem(.flexible(), spacing: 15), GridItem(.flexible())],spacing: 16) {
+                    LazyVGrid(columns: [GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible()), GridItem(.flexible())],spacing: 16) {
                         ForEach(mistakes, id:\.self) { mistake in
                             VStack(alignment: .leading, spacing: 10) {
-                                HangulCardView(onTapGesture: {}, hangulCard: mistake, isLearningView: false)
+                                HangulCardView(onTapGesture: {}, hangulCard: mistake, cardType: .small)
                             }
                         }
                     }

--- a/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Learning/HangulEducationLearningView.swift
+++ b/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Learning/HangulEducationLearningView.swift
@@ -44,6 +44,7 @@ struct HangulEducationLearningView: View {
                             Text("Touch the Cards")
                                 .font(.largeTitle)
                                 .fontWeight(.bold)
+                                .multilineTextAlignment(.center)
                         }
                 
                 VStack(spacing: 25){
@@ -53,7 +54,7 @@ struct HangulEducationLearningView: View {
                         }
                         
                         isOnceFlipped = true
-                    }, hangulCard: educationManager.content[educationManager.index],  isLearningView: true)
+                    }, hangulCard: educationManager.content[educationManager.index], cardType: .large)
                     .environmentObject(educationManager)
                     
                     if educationManager.chapterType == .consonant {
@@ -62,9 +63,9 @@ struct HangulEducationLearningView: View {
                                 .bold()
                                 .frame(maxWidth: .infinity)
                                 .font(.largeTitle)
-                                .padding(15)
+                                .padding(20)
                                 .overlay(RoundedRectangle(cornerRadius: 24)
-                                    .stroke(isExample1Listened ? Color(uiColor: .systemGray4) : .blue , lineWidth: 11))
+                                    .strokeBorder(isExample1Listened ? Color(uiColor: .systemGray4) : .blue , lineWidth: 11))
                                 .onTapGesture {
                                     if !isExample1Listened {
                                         touchCardsCount += 1
@@ -79,9 +80,9 @@ struct HangulEducationLearningView: View {
                                 .bold()
                                 .frame(maxWidth: .infinity)
                                 .font(.largeTitle)
-                                .padding(15)
+                                .padding(20)
                                 .overlay(RoundedRectangle(cornerRadius: 24)
-                                    .stroke(isExample2Listened ? Color(uiColor: .systemGray4) : .blue , lineWidth: 11))
+                                    .strokeBorder(isExample2Listened ? Color(uiColor: .systemGray4) : .blue , lineWidth: 11))
                                 .onTapGesture {
                                     if !isExample2Listened {
                                         touchCardsCount += 1

--- a/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Recap/HangulEducationRecapView.swift
+++ b/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Recap/HangulEducationRecapView.swift
@@ -22,20 +22,22 @@ struct HangulEducationRecapView: View {
                     ProgressView(value: Double(progressValue) / Double(educationManager.content.count * 2 + 2))
                         .padding(.vertical, 16)
                     
-                    HStack{
-                        Text("Recap what you learned to prepare Quiz session")
-                            .font(.largeTitle)
-                            .bold()
+                    VStack {
+                        Text("Before Quiz")
+                            .font(.body)
+                            .fontWeight(.bold)
+                            .foregroundStyle(.secondary)
                         
-                        Spacer()
+                        Text("Recap")
+                            .font(.largeTitle)
+                            .fontWeight(.bold)
                     }
-                    .padding(.bottom, 24)
                     
                     
                     VStack {
-                        LazyVGrid(columns: [GridItem(.flexible(), spacing: 25), GridItem(.flexible())], spacing: 25) {
+                        LazyVGrid(columns: [GridItem(.flexible(), spacing: 15), GridItem(.flexible())], spacing: 15) {
                             ForEach(0 ..< educationManager.content.count, id: \.self) { index in
-                                HangulCardView(onTapGesture: {}, hangulCard: educationManager.content[index], isLearningView: false)
+                                HangulCardView(onTapGesture: {}, hangulCard: educationManager.content[index], cardType: .medium)
                             }
                         }
 


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->

HangulCardVIew 를 업그레이드 하였습니다

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->

1. 자음, 쌍자음, 모음 3종 모두에서 카드 뒷면 대응
2. CardType 을 .small .medium .large 로 나누어 익스텐션으로 타입별로 다른 카드 속성(이미지크기, 글씨크기, 패딩넓이) 리턴
3. ColletionView 의 카드 컬럼 4개로 변경

## Logic
<!-- 작업 내용 1 -->
```swift
enum CardType {
    case small, medium, large
}

extension CardType {
    
    var imageFrame : CGFloat {
        switch self {
        case .small:
            return 48
        case .medium:
            return 130
        case .large:
            return 180
        }
    }
}
```

 ## 작업 결과(이미지 첨부는 선택)
