### PR TITLE
[Feat/#106] ProgressLesson 을 구현하였습니다

### DIFF
--- a/Orum/Orum.xcodeproj/project.pbxproj
+++ b/Orum/Orum.xcodeproj/project.pbxproj
@@ -39,12 +39,11 @@
 		D90B0DFC2AF8697000401C87 /* HangulEducationInstructionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D90B0DFB2AF8697000401C87 /* HangulEducationInstructionView.swift */; };
 		D91B67462B04A3F00030F86D /* HangulQuiz.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91B67452B04A3F00030F86D /* HangulQuiz.swift */; };
 		D91B67482B04B01C0030F86D /* HangulUnitQuizEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91B67472B04B01C0030F86D /* HangulUnitQuizEnum.swift */; };
-		D91B675F2B0609D00030F86D /* PracticeChapterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91B675E2B0609D00030F86D /* PracticeChapterView.swift */; };
-		D91B67612B062AA50030F86D /* PracticeLessonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91B67602B062AA50030F86D /* PracticeLessonView.swift */; };
-		D91B67482B04B01C0030F86D /* HnagulUnitQuizEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91B67472B04B01C0030F86D /* HnagulUnitQuizEnum.swift */; };
 		D91B67582B05BB880030F86D /* HangulEducationQuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91B67572B05BB880030F86D /* HangulEducationQuizView.swift */; };
 		D91B675B2B05C1380030F86D /* EpilogueInstructionView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91B675A2B05C1380030F86D /* EpilogueInstructionView.swift */; };
 		D91B675D2B05C41D0030F86D /* EpilogueQuizVIew.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91B675C2B05C41D0030F86D /* EpilogueQuizVIew.swift */; };
+		D91B675F2B0609D00030F86D /* PracticeChapterView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91B675E2B0609D00030F86D /* PracticeChapterView.swift */; };
+		D91B67612B062AA50030F86D /* PracticeLessonView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D91B67602B062AA50030F86D /* PracticeLessonView.swift */; };
 		D967D1BD2AE2932C008B3379 /* HangulCard.swift in Sources */ = {isa = PBXBuildFile; fileRef = D967D1BC2AE2932C008B3379 /* HangulCard.swift */; };
 		D967D1C12AE2A968008B3379 /* HangulUnit.swift in Sources */ = {isa = PBXBuildFile; fileRef = D967D1C02AE2A968008B3379 /* HangulUnit.swift */; };
 		D967D1C72AE2C761008B3379 /* UIColor+Hex.swift in Sources */ = {isa = PBXBuildFile; fileRef = D967D1C62AE2C761008B3379 /* UIColor+Hex.swift */; };
@@ -61,6 +60,8 @@
 		D96D94452AE777E50077F2C1 /* 라.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = D96D943D2AE777E50077F2C1 /* 라.mp3 */; };
 		D96D94462AE777E50077F2C1 /* 누.mp3 in Resources */ = {isa = PBXBuildFile; fileRef = D96D943E2AE777E50077F2C1 /* 누.mp3 */; };
 		D96D94482AE778680077F2C1 /* SoundManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = D96D94472AE778680077F2C1 /* SoundManager.swift */; };
+		D9756E7D2B0B6C3F0089A39B /* HangulPrologue.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9756E7C2B0B6C3F0089A39B /* HangulPrologue.swift */; };
+		D9756E7F2B0B7DF40089A39B /* HangulUnitPrologueEnum.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9756E7E2B0B7DF40089A39B /* HangulUnitPrologueEnum.swift */; };
 		D98B83FC2AE6EC9C00B47C56 /* ㄴ.json in Resources */ = {isa = PBXBuildFile; fileRef = D98B83FB2AE6EC9C00B47C56 /* ㄴ.json */; };
 		D98B83FE2AE6ECA100B47C56 /* ㄹ.json in Resources */ = {isa = PBXBuildFile; fileRef = D98B83FD2AE6ECA100B47C56 /* ㄹ.json */; };
 		D98B84002AE6F56000B47C56 /* ㄷ.json in Resources */ = {isa = PBXBuildFile; fileRef = D98B83FF2AE6F56000B47C56 /* ㄷ.json */; };
@@ -108,12 +109,11 @@
 		D90B0DFB2AF8697000401C87 /* HangulEducationInstructionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulEducationInstructionView.swift; sourceTree = "<group>"; };
 		D91B67452B04A3F00030F86D /* HangulQuiz.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulQuiz.swift; sourceTree = "<group>"; };
 		D91B67472B04B01C0030F86D /* HangulUnitQuizEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulUnitQuizEnum.swift; sourceTree = "<group>"; };
-		D91B675E2B0609D00030F86D /* PracticeChapterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeChapterView.swift; sourceTree = "<group>"; };
-		D91B67602B062AA50030F86D /* PracticeLessonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeLessonView.swift; sourceTree = "<group>"; };
-		D91B67472B04B01C0030F86D /* HnagulUnitQuizEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HnagulUnitQuizEnum.swift; sourceTree = "<group>"; };
 		D91B67572B05BB880030F86D /* HangulEducationQuizView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulEducationQuizView.swift; sourceTree = "<group>"; };
 		D91B675A2B05C1380030F86D /* EpilogueInstructionView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpilogueInstructionView.swift; sourceTree = "<group>"; };
 		D91B675C2B05C41D0030F86D /* EpilogueQuizVIew.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EpilogueQuizVIew.swift; sourceTree = "<group>"; };
+		D91B675E2B0609D00030F86D /* PracticeChapterView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeChapterView.swift; sourceTree = "<group>"; };
+		D91B67602B062AA50030F86D /* PracticeLessonView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PracticeLessonView.swift; sourceTree = "<group>"; };
 		D967D1BC2AE2932C008B3379 /* HangulCard.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulCard.swift; sourceTree = "<group>"; };
 		D967D1C02AE2A968008B3379 /* HangulUnit.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulUnit.swift; sourceTree = "<group>"; };
 		D967D1C62AE2C761008B3379 /* UIColor+Hex.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIColor+Hex.swift"; sourceTree = "<group>"; };
@@ -129,6 +129,8 @@
 		D96D943D2AE777E50077F2C1 /* 라.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = "라.mp3"; sourceTree = "<group>"; };
 		D96D943E2AE777E50077F2C1 /* 누.mp3 */ = {isa = PBXFileReference; lastKnownFileType = audio.mp3; path = "누.mp3"; sourceTree = "<group>"; };
 		D96D94472AE778680077F2C1 /* SoundManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SoundManager.swift; sourceTree = "<group>"; };
+		D9756E7C2B0B6C3F0089A39B /* HangulPrologue.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulPrologue.swift; sourceTree = "<group>"; };
+		D9756E7E2B0B7DF40089A39B /* HangulUnitPrologueEnum.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulUnitPrologueEnum.swift; sourceTree = "<group>"; };
 		D98B83FB2AE6EC9C00B47C56 /* ㄴ.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "ㄴ.json"; sourceTree = "<group>"; };
 		D98B83FD2AE6ECA100B47C56 /* ㄹ.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "ㄹ.json"; sourceTree = "<group>"; };
 		D98B83FF2AE6F56000B47C56 /* ㄷ.json */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.json; path = "ㄷ.json"; sourceTree = "<group>"; };
@@ -211,8 +213,10 @@
 				D967D1BC2AE2932C008B3379 /* HangulCard.swift */,
 				D91B67452B04A3F00030F86D /* HangulQuiz.swift */,
 				D967D1C02AE2A968008B3379 /* HangulUnit.swift */,
+				D9756E7C2B0B6C3F0089A39B /* HangulPrologue.swift */,
 				9336E2032AF7B0D3000B9E76 /* HangulUnitEnum.swift */,
 				D91B67472B04B01C0030F86D /* HangulUnitQuizEnum.swift */,
+				D9756E7E2B0B7DF40089A39B /* HangulUnitPrologueEnum.swift */,
 			);
 			path = Models;
 			sourceTree = "<group>";
@@ -511,7 +515,8 @@
 				D967D1C72AE2C761008B3379 /* UIColor+Hex.swift in Sources */,
 				93D529792B031BFB00DA743E /* EpilogueLessonView.swift in Sources */,
 				D967D1C92AE40F4E008B3379 /* TTSManager.swift in Sources */,
-				D9037CE92AF0C55A0098DB57 /* HangulEducationQuizView.swift in Sources */,
+				D9756E7D2B0B6C3F0089A39B /* HangulPrologue.swift in Sources */,
+				D9037CE92AF0C55A0098DB57 /* HangulQuizView.swift in Sources */,
 				D9DC995D2B0887B2005FC516 /* PracticeManager.swift in Sources */,
 				D9037CE92AF0C55A0098DB57 /* HangulQuizView.swift in Sources */,
 				9376203D2AF080B500DE2C50 /* HangulEducationView.swift in Sources */,
@@ -537,11 +542,12 @@
 				D91B67482B04B01C0030F86D /* HangulUnitQuizEnum.swift in Sources */,
 				D91B675D2B05C41D0030F86D /* EpilogueQuizVIew.swift in Sources */,
 				937620372AF0807F00DE2C50 /* LearningView.swift in Sources */,
-				D91B67482B04B01C0030F86D /* HnagulUnitQuizEnum.swift in Sources */,
+				D91B67482B04B01C0030F86D /* HangulUnitQuizEnum.swift in Sources */,
 				936BDF062B04CF1D00A609B8 /* LearningLessonView.swift in Sources */,
 				936BDEF72B04A65100A609B8 /* PracticeView.swift in Sources */,
 				937620372AF0807F00DE2C50 /* LearningView.swift in Sources */,
 				D91B67612B062AA50030F86D /* PracticeLessonView.swift in Sources */,
+				D9756E7F2B0B7DF40089A39B /* HangulUnitPrologueEnum.swift in Sources */,
 				D9A9CE0A2AFDF02300F821D6 /* Canvas.swift in Sources */,
 				930F26C92ADD0D8B00896A32 /* OrumApp.swift in Sources */,
 				D9DC995B2B070788005FC516 /* AudioRecorderManager.swift in Sources */,
@@ -552,7 +558,6 @@
 				9336E20E2AF7BD00000B9E76 /* Array<String>+ConcatArray.swift in Sources */,
 				93DA78F42AFB6B35004BB43F /* ConsonantOnboarding.swift in Sources */,
 				D91B675B2B05C1380030F86D /* EpilogueInstructionView.swift in Sources */,
-				9336E2082AF7B306000B9E76 /* String+TranslateHangulToEnglish.swift in Sources */,
 				93194FDD2AF8F28D002C1BE4 /* Dictionary+RawValue.swift in Sources */,
 				D96D94482AE778680077F2C1 /* SoundManager.swift in Sources */,
 				D9037CE72AF0C4270098DB57 /* HangulEducationLearningView.swift in Sources */,

--- a/Orum/Orum/Models/HangulPrologue.swift
+++ b/Orum/Orum/Models/HangulPrologue.swift
@@ -1,0 +1,42 @@
+//
+//  HangulPrologue.swift
+//  Orum
+//
+//  Created by Youngbin Choi on 11/20/23.
+//
+
+import Foundation
+import SwiftUI
+
+struct HangulPrologue {
+
+    let name : String
+    let title : String
+    let text : String
+    let image : [String]
+    let color : [UIColor]
+    let type : PrologueType
+    
+    init(prologueType: PrologueType , name: String) {
+        self.name = name
+        self.title = Constants.Prologue.title[name] ?? ""
+        self.text = Constants.Prologue.text[name] ?? ""
+        self.image = Constants.Prologue.image[name] ?? [""]
+        self.type = prologueType
+        
+        switch prologueType {
+        case .system:
+            color = [UIColor(hex: "33BBED"), UIColor(hex: "18A5D9")]
+        case .consonant:
+            color = [UIColor(hex: "64C396"), UIColor(hex: "2DB173")]
+        case .vowel:
+            color = [UIColor(hex: "FEAA00"), UIColor(hex: "EF8100")]
+        case .batchim:
+            color = [UIColor(hex: "F07E96"), UIColor(hex: "EA4769")]
+        }
+    }
+}
+
+enum PrologueType {
+    case system, consonant, vowel, batchim
+}

--- a/Orum/Orum/Models/HangulQuiz.swift
+++ b/Orum/Orum/Models/HangulQuiz.swift
@@ -46,6 +46,5 @@ struct HangulQuiz {
             self.meaning = Constants.HangulQuiz.meaning[quizName ?? ""] ?? ""
             self.tmi = Constants.HangulQuiz.tmi[quizName ?? ""] ?? ""
         }
-
     }
 }

--- a/Orum/Orum/Models/HangulUnitPrologueEnum.swift
+++ b/Orum/Orum/Models/HangulUnitPrologueEnum.swift
@@ -1,0 +1,41 @@
+//
+//  HangulUnitPrologueEnum.swift
+//  Orum
+//
+//  Created by Youngbin Choi on 11/20/23.
+//
+
+import Foundation
+
+struct HangulUnitPrologueEnum: RawRepresentable { // 자모 분리를 통해서 ㄱ -> g & 가 -> ga, 구 -> gu 로 변환 되게 하기
+    let rawValue: Int
+    
+    static let system: [HangulPrologue] = [
+        HangulPrologue(prologueType: .system, name: "system0"),
+        HangulPrologue(prologueType: .system, name: "system1"),
+        HangulPrologue(prologueType: .system, name: "system2"),
+        HangulPrologue(prologueType: .system, name: "system3"),
+    ]
+    
+    static let consonant0: [HangulPrologue] = [
+        HangulPrologue(prologueType: .consonant, name: "consonant0"),
+        HangulPrologue(prologueType: .consonant, name: "consonant1"),
+        HangulPrologue(prologueType: .consonant, name: "consonant2"),
+        HangulPrologue(prologueType: .consonant, name: "consonant3"),
+    ]
+    
+    static let vowel0: [HangulPrologue] = [
+        HangulPrologue(prologueType: .vowel, name: "system0"),
+        HangulPrologue(prologueType: .vowel, name: "system1"),
+        HangulPrologue(prologueType: .vowel, name: "system2"),
+        HangulPrologue(prologueType: .vowel, name: "system3"),
+    ]
+    
+    static let batchim0: [HangulPrologue] = [
+        HangulPrologue(prologueType: .batchim, name: "system0"),
+        HangulPrologue(prologueType: .batchim, name: "system1"),
+        HangulPrologue(prologueType: .batchim, name: "system2"),
+        HangulPrologue(prologueType: .batchim, name: "system3"),
+    ]
+    
+}

--- a/Orum/Orum/Models/HangulUnitQuizEnum.swift
+++ b/Orum/Orum/Models/HangulUnitQuizEnum.swift
@@ -1,5 +1,5 @@
 //
-//  HnagulUnitQuizEnum.swift
+//  HangulUnitQuizEnum.swift
 //  Orum
 //
 //  Created by Youngbin Choi on 11/15/23.

--- a/Orum/Orum/Utilities/Constants.swift
+++ b/Orum/Orum/Utilities/Constants.swift
@@ -542,4 +542,32 @@ struct Constants {
             "일상회화" : ["안녕하세요", "감사합니다", "죄송합니다", "맛있어요", "주세요", "어디에요", "얼마에요", "도와주세요", "편의점", "병원", "화장실", "좋아요", "싫어요", "네", "아니요"]
         ]
     }
+    
+    struct Prologue {
+        static let title : [String : String] = [
+        
+            "system0" : "Consonants and Vowels",
+            "system1" : "Letter in English and Hangul",
+            "system2" : "Hangul Letter",
+            "system3" : "Word",
+            
+        ]
+        
+        static let text : [String : String] = [
+        
+            "system0" : "Hangul is a character that can be written **phonetically**. It consists of **consonants** and **vowels!**",
+            "system1" : "A letter in English is one alphabet. But a **letter in Hangul** is a **combination of consonants and vowels!**",
+            "system2" : "A **Hangul letter** is a combination of consonants and vowels, so basically the form is **'C+V'** or **'C+V+C'**!",
+            "system3" : "A **Hangul word** is a combination of letters. Is it hard? \n\n Learning Hangul won't be difficult, **so give it a try!**",
+        ]
+        
+        static let image : [String : [String] ] = [
+        
+            "system0" : ["ㄱ"],
+            "system1" : ["ㄴ"],
+            "system2" : ["ㄷ", "ㄹ"],
+            "system3" : ["ㅁ"],
+            
+        ]
+    }
 }

--- a/Orum/Orum/ViewModels/EducationManager.swift
+++ b/Orum/Orum/ViewModels/EducationManager.swift
@@ -45,14 +45,14 @@ class EducationManager: ObservableObject {
         Constants.Lesson.batchim3 : "currentLesson",
     ]
     @AppStorage("wrongCount") var wrongCount: [String:String] = [:]
-
+    
     @Published var content: [HangulCard] = HangulUnitEnum.vowel1
     @Published var quiz: [HangulQuiz] = HangulUnitQuizEnum.consonant1
     @Published var storage: [HangulCard] = []
     @Published var nowStudying: String = Constants.Lesson.vowel1 // 현재 공부하고 있는 단원 (진도와는 무관)
     @Published var chapterType: ChapterType = .vowel
     @Published var lessonType: LessonType = .lesson
-
+    @Published var prologue: [HangulPrologue] = HangulUnitPrologueEnum.system
     @Published var index: Int = 0
     
     init() {
@@ -65,12 +65,14 @@ class EducationManager: ObservableObject {
             quiz = HangulUnitQuizEnum.system
             chapterType = .system
             lessonType = .prologue
+            prologue = HangulUnitPrologueEnum.system
         
         case Constants.Lesson.consonant0:
             content = HangulUnitEnum.consonant0
             quiz = HangulUnitQuizEnum.consonant0
             chapterType = .consonant
             lessonType = .prologue
+            prologue = HangulUnitPrologueEnum.consonant0
             
         case Constants.Lesson.consonant1:
             content = HangulUnitEnum.consonant1
@@ -107,6 +109,7 @@ class EducationManager: ObservableObject {
             quiz = HangulUnitQuizEnum.vowel0
             chapterType = .vowel
             lessonType = .prologue
+            prologue = HangulUnitPrologueEnum.vowel0
 
         case Constants.Lesson.vowel1:
             content = HangulUnitEnum.vowel1
@@ -137,6 +140,7 @@ class EducationManager: ObservableObject {
             quiz = HangulUnitQuizEnum.batchim0
             chapterType = .batchim
             lessonType = .prologue
+            prologue = HangulUnitPrologueEnum.batchim0
 
         case Constants.Lesson.batchim1:
             content = HangulUnitEnum.batchim1

--- a/Orum/Orum/Views/Tabs/Learning/HangulEducation/PrologueLesson/PrologueLessonView.swift
+++ b/Orum/Orum/Views/Tabs/Learning/HangulEducation/PrologueLesson/PrologueLessonView.swift
@@ -8,24 +8,122 @@
 import SwiftUI
 
 struct PrologueLessonView: View {
+    
     @Binding var isPresented: Bool
+    @EnvironmentObject var educationManager: EducationManager
+    
+    var prologuePage : HangulPrologue {
+        educationManager.prologue[educationManager.index]
+    }
     
     var body: some View {
-        NavigationStack {
-            VStack {
-                Text("Prologue")
+        NavigationStack{
+            ZStack{
+                    VStack(spacing: 0){
+                        VStack(spacing: 20){
+                            Text(prologuePage.title)
+                                .bold()
+                                .font(.title)
+                                .foregroundStyle(Color(uiColor: prologuePage.color[0]))
+                                .multilineTextAlignment(.center)
+                            Text(.init(prologuePage.text))
+                                .font(.body)
+                                .multilineTextAlignment(.center)
+                            Spacer()
+                        }
+                        .frame(height: 200)
+                        RoundedRectangle(cornerRadius: 16)
+                            .frame(width: 358, height: 358)
+                            .foregroundColor(Color(uiColor: UIColor(hex: "F8F8F8")))
+                            .overlay {
+                                if prologuePage.image.count == 1 {
+                                    Image(prologuePage.image[0])
+                                        .resizable()
+                                        .scaledToFit()
+                                } else {
+                                    LazyHStack{
+                                        PageView(images: prologuePage.image)
+                                    }
+                                }
+                            }
+                            .padding(.bottom, 100)
+                        Spacer()
+                    }
+                    .padding(.horizontal, 16)
+//                VStack {
+//                    Spacer()
+//                    
+//                    HStack {
+//                        Button(action: {}, label: {
+//                            Text("Continue")
+//                                .frame(maxWidth: .infinity)
+//                                .padding(.vertical, 8)
+//                        })
+//                        .buttonStyle(.borderedProminent)
+//                        .hidden()
+//                    }
+//                    .padding(24)
+//                    .background(.ultraThinMaterial)
+//                }
+                
+                VStack {
+                    Spacer()
+                    
+                    Button(action: {
+                        if educationManager.index < educationManager.prologue.count - 1 {
+                            educationManager.index += 1
+                        } else {
+                            isPresented.toggle()
+                            educationManager.index = 0
+                        }
+                    }, label: {
+                        Text("Continue")
+                            .frame(maxWidth: .infinity)
+                            .padding(.vertical, 8)
+                            .bold()
+                            
+                    })
+                    .tint(Color(uiColor: prologuePage.color[1]))
+                    .buttonStyle(.borderedProminent)
+                    .padding(.horizontal, 24)
+                    .padding(.bottom, 24)
+                }
             }
             .navigationBarItems(leading: Button(action: {
-                isPresented.toggle()
+                educationManager.index -= 1
             }, label: {
-                Image(systemName: "xmark.circle.fill")
+                Image(systemName: "chevron.left")
                     .font(.title3)
-                    .foregroundStyle(.blue, Color(uiColor: .secondarySystemFill))
-            }))
+                    .foregroundStyle(educationManager.index == 0 ? .clear : Color(uiColor: .systemGray3))
+            })
+                .disabled(educationManager.index == 0 ? true : false)
+            )
+            .buttonStyle(.plain)
+
+            
         }
+    }
+}
+
+struct PageView : View {
+    
+    var images: [String]
+    
+    var body: some View {
+        TabView {
+            ForEach(0 ..< images.count){ index in
+                Image(images[index])
+                    .resizable()
+                    .scaledToFit()
+            }
+        }
+        .frame(width: 358, height: 358)
+        .tabViewStyle(PageTabViewStyle())
+        .indexViewStyle(PageIndexViewStyle(backgroundDisplayMode: .always))
     }
 }
 
 #Preview {
     PrologueLessonView(isPresented: .constant(true))
+        .environmentObject(EducationManager())
 }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->

 ProgressLesson 을 구현하였습니다

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->
1. educationManager 에서 HangulPrologue 를 만들어 뷰로 보내줍니다
2. 프롤로그 페이지중 좌우 페이징뷰가 있는 이미지가 있기 때문에 Constant 에 Prologue 의 image 를 스트링배열로 만들어
배열의 개수에 따라서 분기처리를 합니다

## Logic
<!-- 작업 내용 1 -->
```swift
                            .overlay {
                                if prologuePage.image.count == 1 {
                                    Image(prologuePage.image[0])
                                        .resizable()
                                        .scaledToFit()
                                } else {
                                    LazyHStack{
                                        PageView(images: prologuePage.image)
                                    }
                                }
                            }

```

 ## 작업 결과(이미지 첨부는 선택)
