### PR TITLE
[Feat/#123] Lesson Ending View

### DIFF
--- a/Orum/Orum.xcodeproj/project.pbxproj
+++ b/Orum/Orum.xcodeproj/project.pbxproj
@@ -40,6 +40,8 @@
 		93EF74AC2B04DA08003111CD /* OnboardingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93EF74AB2B04DA08003111CD /* OnboardingView.swift */; };
 		93F1F5B82B0E2CF200C6D64C /* View+NavigationBarColor.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F1F5B72B0E2CF200C6D64C /* View+NavigationBarColor.swift */; };
 		93F1F5BA2B0E2D3800C6D64C /* NavigationBarModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F1F5B92B0E2D3800C6D64C /* NavigationBarModifier.swift */; };
+		93F1F5BC2B0F789D00C6D64C /* LessonEndingView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 93F1F5BB2B0F789D00C6D64C /* LessonEndingView.swift */; };
+		93F1F5BF2B0F7D6A00C6D64C /* ConfettiSwiftUI in Frameworks */ = {isa = PBXBuildFile; productRef = 93F1F5BE2B0F7D6A00C6D64C /* ConfettiSwiftUI */; };
 		D9037CE72AF0C4270098DB57 /* HangulEducationLearningView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9037CE62AF0C4260098DB57 /* HangulEducationLearningView.swift */; };
 		D9037CE92AF0C55A0098DB57 /* HangulQuizView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9037CE82AF0C55A0098DB57 /* HangulQuizView.swift */; };
 		D9037D092AF0D2B70098DB57 /* HangulCardView.swift in Sources */ = {isa = PBXBuildFile; fileRef = D9037D082AF0D2B70098DB57 /* HangulCardView.swift */; };
@@ -120,6 +122,7 @@
 		93EF74AB2B04DA08003111CD /* OnboardingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = OnboardingView.swift; sourceTree = "<group>"; };
 		93F1F5B72B0E2CF200C6D64C /* View+NavigationBarColor.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "View+NavigationBarColor.swift"; sourceTree = "<group>"; };
 		93F1F5B92B0E2D3800C6D64C /* NavigationBarModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = NavigationBarModifier.swift; sourceTree = "<group>"; };
+		93F1F5BB2B0F789D00C6D64C /* LessonEndingView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = LessonEndingView.swift; sourceTree = "<group>"; };
 		D9037CE62AF0C4260098DB57 /* HangulEducationLearningView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulEducationLearningView.swift; sourceTree = "<group>"; };
 		D9037CE82AF0C55A0098DB57 /* HangulQuizView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulQuizView.swift; sourceTree = "<group>"; };
 		D9037D082AF0D2B70098DB57 /* HangulCardView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HangulCardView.swift; sourceTree = "<group>"; };
@@ -169,6 +172,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				93F1F5BF2B0F7D6A00C6D64C /* ConfettiSwiftUI in Frameworks */,
 				D96BAC682AE6C35600613540 /* Lottie in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -386,6 +390,7 @@
 				936BDF032B04B3E800A609B8 /* PrologueLesson */,
 				936BDF012B04B2E800A609B8 /* LearningLesson */,
 				936BDF042B04B3F800A609B8 /* EpilogueLesson */,
+				93F1F5BB2B0F789D00C6D64C /* LessonEndingView.swift */,
 			);
 			path = HangulEducation;
 			sourceTree = "<group>";
@@ -484,6 +489,7 @@
 			name = Orum;
 			packageProductDependencies = (
 				D96BAC672AE6C35600613540 /* Lottie */,
+				93F1F5BE2B0F7D6A00C6D64C /* ConfettiSwiftUI */,
 			);
 			productName = Orum;
 			productReference = 930F26C52ADD0D8B00896A32 /* Orum.app */;
@@ -517,6 +523,7 @@
 			mainGroup = 930F26BC2ADD0D8A00896A32;
 			packageReferences = (
 				D96BAC662AE6C35600613540 /* XCRemoteSwiftPackageReference "lottie-ios" */,
+				93F1F5BD2B0F7D6A00C6D64C /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */,
 			);
 			productRefGroup = 930F26C62ADD0D8B00896A32 /* Products */;
 			projectDirPath = "";
@@ -579,6 +586,7 @@
 				93EF74AC2B04DA08003111CD /* OnboardingView.swift in Sources */,
 				D96BAC6A2AE6C37800613540 /* LottieView.swift in Sources */,
 				9336E20A2AF7B505000B9E76 /* Constants.swift in Sources */,
+				93F1F5BC2B0F789D00C6D64C /* LessonEndingView.swift in Sources */,
 				93DA78EF2AFB6233004BB43F /* VowelDrawingView.swift in Sources */,
 				D967D1BD2AE2932C008B3379 /* HangulCard.swift in Sources */,
 				93194FD32AF8B75A002C1BE4 /* View+CornerRadius.swift in Sources */,
@@ -586,7 +594,7 @@
 				D967D1C12AE2A968008B3379 /* HangulUnit.swift in Sources */,
 				D91B67462B04A3F00030F86D /* HangulQuiz.swift in Sources */,
 				93F1F5BA2B0E2D3800C6D64C /* NavigationBarModifier.swift in Sources */,
-				D91B67482B04B01C0030F86D /* HnagulUnitQuizEnum.swift in Sources */,
+				D91B67482B04B01C0030F86D /* HangulUnitQuizEnum.swift in Sources */,
 				93D224EC2B0C9AD600A8FE4D /* OffsetKey.swift in Sources */,
 				D91B675F2B0609D00030F86D /* PracticeChapterView.swift in Sources */,
 				9336E2042AF7B0D3000B9E76 /* HangulUnitEnum.swift in Sources */,
@@ -760,7 +768,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Orum/Preview Content\"";
-				DEVELOPMENT_TEAM = 3X7HFG8283;
 				DEVELOPMENT_TEAM = 7DAR847RN7;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -804,7 +811,6 @@
 				CODE_SIGN_STYLE = Automatic;
 				CURRENT_PROJECT_VERSION = 1;
 				DEVELOPMENT_ASSET_PATHS = "\"Orum/Preview Content\"";
-				DEVELOPMENT_TEAM = 3X7HFG8283;
 				DEVELOPMENT_TEAM = 7DAR847RN7;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_PREVIEWS = YES;
@@ -863,6 +869,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		93F1F5BD2B0F7D6A00C6D64C /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/simibac/ConfettiSwiftUI.git";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 1.1.0;
+			};
+		};
 		D96BAC662AE6C35600613540 /* XCRemoteSwiftPackageReference "lottie-ios" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/airbnb/lottie-ios.git";
@@ -874,6 +888,11 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		93F1F5BE2B0F7D6A00C6D64C /* ConfettiSwiftUI */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 93F1F5BD2B0F7D6A00C6D64C /* XCRemoteSwiftPackageReference "ConfettiSwiftUI" */;
+			productName = ConfettiSwiftUI;
+		};
 		D96BAC672AE6C35600613540 /* Lottie */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = D96BAC662AE6C35600613540 /* XCRemoteSwiftPackageReference "lottie-ios" */;

--- a/Orum/Orum.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Orum/Orum.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,15 @@
 {
   "pins" : [
     {
+      "identity" : "confettiswiftui",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/simibac/ConfettiSwiftUI.git",
+      "state" : {
+        "revision" : "f45961f97bbae6fff6e2e64546fea0189425ad92",
+        "version" : "1.1.0"
+      }
+    },
+    {
       "identity" : "lottie-ios",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/airbnb/lottie-ios.git",

--- a/Orum/Orum/Views/Components/HangulQuizView.swift
+++ b/Orum/Orum/Views/Components/HangulQuizView.swift
@@ -175,16 +175,6 @@ struct HangulQuizView: View {
                         }
                     }
                 }
-                .navigationTitle(educationManager.nowStudying)
-                .navigationBarTitleDisplayMode(.inline)
-                .navigationBarItems(leading: Button(action: {
-                    isPresented.toggle()
-                }, label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.title3)
-                        .foregroundStyle(.blue, Color(uiColor: .secondarySystemFill))
-                        .symbolRenderingMode(.palette)
-                }))
                 
                 //버튼 뒷배경
                 VStack {
@@ -276,8 +266,9 @@ struct HangulQuizView: View {
                                         }
                                         
                                         if educationManager.quiz.isEmpty {
-                                            educationManager.endLesson()
-                                            isPresented.toggle()
+                                            educationManager.currentEducation = .end
+//                                            educationManager.endLesson()
+//                                            isPresented.toggle()
                                         }
                                         else {
                                             ind = 0

--- a/Orum/Orum/Views/Tabs/Learning/HangulEducation/EpilogueLesson/EpilogueInstructionView.swift
+++ b/Orum/Orum/Views/Tabs/Learning/HangulEducation/EpilogueLesson/EpilogueInstructionView.swift
@@ -20,9 +20,7 @@ struct EpilogueInstructionView: View {
                 VStack {
                     ProgressView(value: Double(progressValue) / Double(educationManager.content.count * 2 + 2))
                         .padding(.vertical, 16)
-                    
-                    Text("Epilogue Instruction")
-                    
+                                        
 //                    switch educationManager.chapterType {
 //                    case .system:
 //                        Spacer()
@@ -35,16 +33,6 @@ struct EpilogueInstructionView: View {
 //                    }
                 }
                 .padding(.horizontal, 16)
-                .navigationTitle(educationManager.nowStudying)
-                .navigationBarTitleDisplayMode(.inline)
-                .navigationBarItems(leading: Button(action: {
-                    isPresented.toggle()
-                }, label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.title3)
-                        .foregroundStyle(.blue, Color(uiColor: .secondarySystemFill))
-                        .symbolRenderingMode(.palette)
-            }))
             }
             
             // 버튼 뒷 배경
@@ -85,6 +73,6 @@ struct EpilogueInstructionView: View {
 }
 
 #Preview {
-    EpilogueInstructionView(currentEpliogue: .constant(.instruction), progressValue: .constant(0),isPresented: .constant(false))
+    EpilogueInstructionView(currentEpliogue: .constant(.quiz), progressValue: .constant(0),isPresented: .constant(false))
         .environmentObject(EducationManager())
 }

--- a/Orum/Orum/Views/Tabs/Learning/HangulEducation/EpilogueLesson/EpilogueLessonView.swift
+++ b/Orum/Orum/Views/Tabs/Learning/HangulEducation/EpilogueLesson/EpilogueLessonView.swift
@@ -8,8 +8,9 @@
 import SwiftUI
 
 enum CurrentEpliogue {
-    case instruction
+//    case instruction
     case quiz
+    case end
 }
 
 struct EpilogueLessonView: View {
@@ -17,20 +18,19 @@ struct EpilogueLessonView: View {
     
     @EnvironmentObject var educationManager: EducationManager
     
-    @State var currentEpliogue: CurrentEpliogue = .instruction
+    @State var currentEpliogue: CurrentEpliogue = .quiz
     @State var progressValue: Int = 0
     
     var body: some View {
         switch currentEpliogue {
-            
-        case .instruction:
-            EpilogueInstructionView(currentEpliogue: $currentEpliogue, progressValue: $progressValue, isPresented: $isPresented)
-                .environmentObject(educationManager)
-            
         case .quiz:
             EpilogueQuizVIew(progressValue: $progressValue, isPresented: $isPresented)
                 .environmentObject(educationManager)
                 .transition(.opacity)
+            
+        case .end:
+            LessonEndingView(isPresented: $isPresented)
+                .environmentObject(educationManager)
         }
     }
 }

--- a/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Learning/BatchimLearningView.swift
+++ b/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Learning/BatchimLearningView.swift
@@ -66,15 +66,6 @@ struct BatchimLearningView: View {
                     }
                 }
                 .padding(.horizontal, 16)
-                .navigationTitle(educationManager.nowStudying)
-                .navigationBarTitleDisplayMode(.inline)
-                .navigationBarItems(leading: Button(action: {
-                    isPresented.toggle()
-                }, label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.title3)
-                        .foregroundStyle(.blue, Color(uiColor: .secondarySystemFill))
-            }))
             }
             
             // 버튼 뒷 배경

--- a/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Learning/ComplexBatchimLearningView.swift
+++ b/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Learning/ComplexBatchimLearningView.swift
@@ -47,15 +47,6 @@ struct ComplexBatchimLearningView: View {
                     }
                 }
                 .padding(.horizontal, 16)
-                .navigationTitle(educationManager.nowStudying)
-                .navigationBarTitleDisplayMode(.inline)
-                .navigationBarItems(leading: Button(action: {
-                    isPresented.toggle()
-                }, label: {
-                    Image(systemName: "xmark.circle.fill")
-                        .font(.title3)
-                        .foregroundStyle(.blue, Color(uiColor: .secondarySystemFill))
-            }))
             }
             
             // 버튼 뒷 배경

--- a/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Learning/VowelDrawingView.swift
+++ b/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Learning/VowelDrawingView.swift
@@ -22,19 +22,9 @@ struct VowelDrawingView: View {
                     .padding(.vertical, 16)
                     .padding(.horizontal, 16)
                 
-                //            Divider()
                 Canvas(writingCount: $writingCount)
                     .environmentObject(educationManager)
             }
-            .navigationTitle(educationManager.nowStudying)
-            .navigationBarTitleDisplayMode(.inline)
-            .navigationBarItems(leading: Button(action: {
-                isPresented.toggle()
-            }, label: {
-                Image(systemName: "xmark.circle.fill")
-                    .font(.title3)
-                    .foregroundStyle(.blue, Color(uiColor: .secondarySystemFill))
-            }))
             
             // 버튼 뒷 배경
             ZStack{
@@ -65,7 +55,6 @@ struct VowelDrawingView: View {
                     })
                     .buttonStyle(.borderedProminent)
                     .padding(.horizontal, 24)
-//                    .padding(.bottom, 24)
                     .disabled(writingCount < 3)
                 }
             }

--- a/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/LearningLessonView.swift
+++ b/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/LearningLessonView.swift
@@ -17,6 +17,7 @@ enum CurrentEducation {
     case quiz
     case batchim
     case complexBatchim
+    case end
 }
 
 struct LearningLessonView: View {
@@ -55,11 +56,17 @@ struct LearningLessonView: View {
             HangulEducationQuizView(progressValue: $progressValue, isPresented: $isPresented)
                 .environmentObject(educationManager)
                 .transition(.opacity)
+        
         case .batchim:
             BatchimLearningView(progressValue: $progressValue, currentEducation: $currentEducation, isPresented: $isPresented)
                 .environmentObject(educationManager)
+        
         case .complexBatchim:
             ComplexBatchimLearningView(progressValue: $progressValue, currentEducation: $currentEducation, isPresented: $isPresented)
+                .environmentObject(educationManager)
+        
+        case .end:
+            LessonEndingView(isPresented: $isPresented)
                 .environmentObject(educationManager)
         }
     }

--- a/Orum/Orum/Views/Tabs/Learning/HangulEducation/LessonEndingView.swift
+++ b/Orum/Orum/Views/Tabs/Learning/HangulEducation/LessonEndingView.swift
@@ -1,0 +1,56 @@
+//
+//  LessonEndingView.swift
+//  Orum
+//
+//  Created by 차차 on 11/23/23.
+//
+
+import ConfettiSwiftUI
+import SwiftUI
+
+struct LessonEndingView: View {
+    @Binding var isPresented: Bool
+    
+    @EnvironmentObject var educationManager: EducationManager
+    
+    @State private var counter: Int = 0
+    
+    var body: some View {
+        VStack {
+            Spacer()
+            
+            Text("Well Done!")
+                .bold()
+                .font(.largeTitle)
+                .confettiCannon(counter: $counter, num: 50, confettis: [.image("ㄱ"),.image("ㄴ"),.image("ㄷ"),.image("ㄹ")], confettiSize: 40)
+
+            Spacer()
+            
+            VStack(spacing: 8) {
+                Button(action: {
+                    educationManager.endLesson()
+                    isPresented.toggle()
+                }, label: {
+                    Text("Exit")
+                })
+                
+                Button(action: {
+                    
+                }, label: {
+                    Text("Next Lesson \(Image(systemName: "forward.fill"))")
+                        .frame(maxWidth: .infinity)
+                        .padding(.vertical, 14)
+                })
+                .buttonStyle(.borderedProminent)
+            }
+        }
+        .padding(.horizontal, 16)
+        .onAppear {
+            counter += 1
+        }
+    }
+}
+
+#Preview {
+    LessonEndingView(isPresented: .constant(false))
+}

--- a/Orum/Orum/Views/Tabs/Learning/LearningView.swift
+++ b/Orum/Orum/Views/Tabs/Learning/LearningView.swift
@@ -84,14 +84,6 @@ struct LearningView: View {
             .fullScreenCover(isPresented: $prologue, content: {
                 PrologueLessonView(isPresented: $prologue)
                     .environmentObject(educationManager)
-                    .overlay(alignment: .topLeading){
-                        Button(action: {
-                            prologue.toggle()
-                        }, label: {
-                            Image(systemName: "xmark")
-                        })
-                        .padding(.horizontal, 16)
-                    }
             })
             .overlay {
                 if let currentLesson = currentLesson, isPresented {


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->
- Lesson Ending View를 구현하였습니다.
- 작업 이슈: #123 

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->

- LessonEndingView 구현
- Confetti Effect Package 추가
- LesonView 중복된 BackButton 제거
- PrologueView 중복된 BackButton 제거

## Logic
<!-- 작업 내용 1 -->
```swift
Text("Well Done!")
                .bold()
                .font(.largeTitle)
                .confettiCannon(counter: $counter, num: 50, confettis: [.image("ㄱ"),.image("ㄴ"),.image("ㄷ"),.image("ㄹ")], confettiSize: 40)
```
SwiftConfetti를 활용하여 Confetti 효과를 추가하였습니다.

 ## 작업 결과(이미지 첨부는 선택)
![Simulator Screen Recording - iPhone 15 - 2023-11-23 at 21 46 13](https://github.com/DeveloperAcademy-POSTECH/MacC-Team3-BluePeriodClub/assets/58865827/5d115222-1b70-4b51-ac32-bd7f3b37b080)
![Simulator Screen Recording - iPhone 15 - 2023-11-23 at 21 47 15](https://github.com/DeveloperAcademy-POSTECH/MacC-Team3-BluePeriodClub/assets/58865827/52f6e180-3c72-45d0-a852-00cad03fb18a)
