### PR TITLE
[Feat/#135] Hangul Education Instruction View Epilogue case UI

### DIFF
--- a/Orum/Orum.xcodeproj/xcuserdata/chacha.xcuserdatad/xcschemes/xcschememanagement.plist
+++ b/Orum/Orum.xcodeproj/xcuserdata/chacha.xcuserdatad/xcschemes/xcschememanagement.plist
@@ -7,7 +7,7 @@
 		<key>Orum.xcscheme_^#shared#^_</key>
 		<dict>
 			<key>orderHint</key>
-			<integer>0</integer>
+			<integer>1</integer>
 		</dict>
 	</dict>
 </dict>

--- a/Orum/Orum/Models/Lesson.swift
+++ b/Orum/Orum/Models/Lesson.swift
@@ -15,12 +15,12 @@ struct Lesson: Identifiable {
     let lessonState: String
     let completedDates: String
     
-    init(lessonName: String) {
+    init(lessonName: String, lessonType: LessonType, chapterType: ChapterType) {
         let educationManager = EducationManager()
         
         self.lessonName = lessonName
-        self.lessonType = .lesson
-        self.chapterType = .consonant
+        self.lessonType = lessonType
+        self.chapterType = chapterType
         self.lessonState = educationManager.lessonState[lessonName] ?? "locked"
         self.completedDates = educationManager.completedDates[lessonName] ?? ""
     }
@@ -35,30 +35,30 @@ let lessons: [[Lesson]] = [
 ]
 
 let hangulSystemLesson: [Lesson] = [
-    Lesson(lessonName: Constants.Lesson.system)
+    Lesson(lessonName: Constants.Lesson.system, lessonType: .prologue, chapterType: .system)
 ]
 
 let consonantLesson: [Lesson] = [
-    Lesson(lessonName: Constants.Lesson.consonant0),
-    Lesson(lessonName: Constants.Lesson.consonant1),
-    Lesson(lessonName: Constants.Lesson.consonant2),
-    Lesson(lessonName: Constants.Lesson.consonant3),
-    Lesson(lessonName: Constants.Lesson.consonant4),
-    Lesson(lessonName: Constants.Lesson.consonant5),
+    Lesson(lessonName: Constants.Lesson.consonant0, lessonType: .prologue, chapterType: .consonant),
+    Lesson(lessonName: Constants.Lesson.consonant1, lessonType: .lesson, chapterType: .consonant),
+    Lesson(lessonName: Constants.Lesson.consonant2, lessonType: .lesson, chapterType: .consonant),
+    Lesson(lessonName: Constants.Lesson.consonant3, lessonType: .lesson, chapterType: .consonant),
+    Lesson(lessonName: Constants.Lesson.consonant4, lessonType: .lesson, chapterType: .consonant),
+    Lesson(lessonName: Constants.Lesson.consonant5, lessonType: .epilogue, chapterType: .consonant),
     ]
 
 let vowelLesson: [Lesson] = [
-    Lesson(lessonName: Constants.Lesson.vowel0),
-    Lesson(lessonName: Constants.Lesson.vowel1),
-    Lesson(lessonName: Constants.Lesson.vowel2),
-    Lesson(lessonName: Constants.Lesson.vowel3),
-    Lesson(lessonName: Constants.Lesson.vowel4),
+    Lesson(lessonName: Constants.Lesson.vowel0, lessonType: .prologue, chapterType: .vowel),
+    Lesson(lessonName: Constants.Lesson.vowel1, lessonType: .lesson, chapterType: .vowel),
+    Lesson(lessonName: Constants.Lesson.vowel2, lessonType: .lesson, chapterType: .vowel),
+    Lesson(lessonName: Constants.Lesson.vowel3, lessonType: .lesson, chapterType: .vowel),
+    Lesson(lessonName: Constants.Lesson.vowel4, lessonType: .epilogue, chapterType: .vowel),
 ]
 
 let batchimLesson: [Lesson] = [
-    Lesson(lessonName: Constants.Lesson.batchim0),
-    Lesson(lessonName: Constants.Lesson.batchim1),
-    Lesson(lessonName: Constants.Lesson.batchim2),
-    Lesson(lessonName: Constants.Lesson.batchim3),
+    Lesson(lessonName: Constants.Lesson.batchim0, lessonType: .prologue, chapterType: .batchim),
+    Lesson(lessonName: Constants.Lesson.batchim1, lessonType: .lesson, chapterType: .batchim),
+    Lesson(lessonName: Constants.Lesson.batchim2, lessonType: .lesson, chapterType: .batchim),
+    Lesson(lessonName: Constants.Lesson.batchim3, lessonType: .epilogue, chapterType: .batchim),
 ]
 

--- a/Orum/Orum/Utilities/Constants.swift
+++ b/Orum/Orum/Utilities/Constants.swift
@@ -68,6 +68,10 @@ struct Constants {
             Constants.Lesson.batchim2: ["ㅎ",],
             Constants.Lesson.batchim3 : ["Epilogue"]
         ]
+        
+        static let instructionText : [String] = [
+            "",
+        ]
     }
     
     struct Hangul {

--- a/Orum/Orum/Utilities/Extensions/LearningView/LearningView+HangulEducationInstructionView.swift
+++ b/Orum/Orum/Utilities/Extensions/LearningView/LearningView+HangulEducationInstructionView.swift
@@ -40,30 +40,63 @@ extension LearningView {
                             Spacer()
                             
                         case .lesson:
-                            Text("\(Constants.Lesson.lessonComponent[lesson.lessonName]!.concatArray(isComma: false))")
-                                .frame(maxWidth: .infinity)
-                                .font(.largeTitle)
-                                .bold()
-                                .multilineTextAlignment(.center)
-                                .padding(.horizontal, 8)
-                                .padding(.vertical, 48)
-                                .background(
-                                    RoundedRectangle(cornerRadius: 16)
-                                        .foregroundStyle(Color(uiColor: .secondarySystemFill))
-                                )
-                            
-                            
-                            Text("These batchim don't appear \nfrequently and have very complex \nrules. Instead of memorizing them, \nwhen you encounter ㅎ or complex \nbatchim refer to the app for pronunciation. I'll always be here, ready to assist.")
-                                .font(.title2)
-                            
-                            Spacer()
-                                .frame(height: 100)
+                            VStack(spacing: 16) {
+                                Text("\(Constants.Lesson.lessonComponent[lesson.lessonName]!.concatArray(isComma: false))")
+                                    .frame(maxWidth: .infinity)
+                                    .font(.largeTitle)
+                                    .bold()
+                                    .multilineTextAlignment(.center)
+                                    .padding(.horizontal, 8)
+                                    .padding(.vertical, 48)
+                                    .background(
+                                        RoundedRectangle(cornerRadius: 16)
+                                            .foregroundStyle(Color(uiColor: .secondarySystemFill))
+                                    )
+                                
+                                
+                                Text("These batchim don't appear \nfrequently and have very complex \nrules. Instead of memorizing them, \nwhen you encounter ㅎ or complex \nbatchim refer to the app for pronunciation. I'll always be here, ready to assist.")
+                                    .font(.title2)
+                                
+                                Spacer()
+                                    .frame(height: 100)
+                            }
+                            .padding(.horizontal, 32)
                             
                         case .epilogue:
-                            Spacer()
+                            Text("Let's review the consonant we learned through a quiz.")
+                                .bold()
+                                .font(.title2)
+                                .padding(.horizontal, 32)
+                            
+                            VStack {
+                                switch lesson.chapterType {
+                                case .system:
+                                    EmptyView()
+                                    
+                                case .consonant:
+                                    LazyVGrid(columns: [GridItem(.flexible(), spacing: 16),GridItem(.flexible(), spacing: 16)],spacing: 16, content: {
+                                        ForEach(Constants.Hangul.consonants, id: \.self) { consonant in
+                                            HangulCardView(onTapGesture: {}, hangulCard: HangulCard(name: consonant), cardType: .medium, canBorderColorChange: false)
+                                        }
+                                    })
+                                    
+                                case .vowel:
+                                    LazyVGrid(columns: [GridItem(.flexible(), spacing: 16),GridItem(.flexible(), spacing: 16)],spacing: 16, content: {
+                                        ForEach(Constants.Hangul.vowels, id: \.self) { vowel in
+                                            HangulCardView(onTapGesture: {}, hangulCard: HangulCard(name: vowel), cardType: .medium, canBorderColorChange: false)
+                                        }
+                                    })
+                                    
+                                case.batchim:
+                                    //                                    ForEach(Constants.Hangul.batchim, id: \.self) { i in
+                                    //                                        HangulCardView(onTapGesture: {}, hangulCard: HangulCard(name: "ㄱ"), cardType: .medium, canBorderColorChange: false)
+                                    //                                    }
+                                    EmptyView()
+                                }
+                            }
+                            .padding(.horizontal, 16)
                         }
                     }
-                    .padding(.horizontal, 32)
                     .transition(.move(edge: .top))
                     .background(.white)
                 }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->
- Hangul Education View의 Epilogue Case UI를 구현했습니다.
- 작업 이슈: #135 

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->
- Hangul Education View의 Epilogue Case UI 구현
- 
## Logic
<!-- 작업 내용 1 -->
```swift
```

 ## 작업 결과(이미지 첨부는 선택)
<img width="420" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team3-BluePeriodClub/assets/58865827/e4102436-cc36-4d30-849a-6409222e436f">
