### PR TITLE
[Feat/#137] Changing QuizView UI

### DIFF
--- a/Orum/Orum/Assets.xcassets/국밥.imageset/Contents.json
+++ b/Orum/Orum/Assets.xcassets/국밥.imageset/Contents.json
@@ -1,7 +1,7 @@
 {
   "images" : [
     {
-      "filename" : "국밥.png",
+      "filename" : "국밥.png",
       "idiom" : "universal",
       "scale" : "1x"
     },

--- a/Orum/Orum/Models/HangulQuiz.swift
+++ b/Orum/Orum/Models/HangulQuiz.swift
@@ -17,9 +17,9 @@ struct HangulQuiz {
     let tmi : String
     
     init(lessonType: LessonType, name: String) {
-        let quizName  = Constants.Hangul.consonantQuiz[name]?[0]
-        
         if Constants.Hangul.consonants.contains(name) {
+            let quizName  = Constants.Hangul.consonantQuiz[name]?[0]
+
             self.lessonType = lessonType
             self.name = name
             self.sound = Constants.Hangul.consonantSound[name] ?? ""
@@ -29,19 +29,23 @@ struct HangulQuiz {
             self.tmi = Constants.HangulQuiz.tmi[quizName ?? ""] ?? ""
         }
         else if Constants.Hangul.vowels.contains(name) {
+            let quizName  = Constants.Hangul.vowelQuiz[name]?[0]
+
             self.lessonType = lessonType
             self.name = name
             self.sound = Constants.Hangul.vowelSound[name] ?? ""
-            self.quizName = Constants.Hangul.consonantQuiz[name]?[lessonType == .lesson ? 0 : 1] ?? ""
+            self.quizName = Constants.Hangul.vowelQuiz[name]?[lessonType == .lesson ? 0 : 1] ?? ""
             self.options = Constants.HangulQuiz.options[quizName ?? ""] ?? [""]
             self.meaning = Constants.HangulQuiz.meaning[quizName ?? ""] ?? ""
             self.tmi = Constants.HangulQuiz.tmi[quizName ?? ""] ?? ""
         }
         else {
+            let quizName  = Constants.Hangul.consonantQuiz[name]?[0]
+
             self.lessonType = lessonType
             self.name = name
-            self.sound = Constants.Hangul.consonantSound[name] ?? ""
-            self.quizName = Constants.Hangul.consonantQuiz[name]?[lessonType == .lesson ? 0 : 1] ?? ""
+            self.sound = Constants.Hangul.consonantSound[name] ?? "" // change to batchim sound ... ?
+            self.quizName = Constants.Hangul.consonantQuiz[name]?[lessonType == .lesson ? 0 : 1] ?? "" // change to batchim quiz
             self.options = Constants.HangulQuiz.options[quizName ?? ""] ?? [""]
             self.meaning = Constants.HangulQuiz.meaning[quizName ?? ""] ?? ""
             self.tmi = Constants.HangulQuiz.tmi[quizName ?? ""] ?? ""

--- a/Orum/Orum/Views/Components/HangulQuizView.swift
+++ b/Orum/Orum/Views/Components/HangulQuizView.swift
@@ -34,7 +34,7 @@ struct HangulQuizView: View {
         ScrollViewReader { proxy in
             ZStack {
                 ScrollView {
-                    VStack {
+                    VStack(spacing: 16) {
                         ProgressView(value: Double(progressValue) / Double(educationManager.content.count * 2 + 2))
                             .padding(.vertical, 16)
                             .id(topID)
@@ -50,105 +50,105 @@ struct HangulQuizView: View {
                                 .fontWeight(.bold)
                                 .multilineTextAlignment(.center)
                         }
+                        .padding(.bottom, 9)
+                        
+                        
                         VStack {
-                            HStack{
-                                Spacer()
-                                
-                                ZStack(alignment: .leading) {
-                                    Text(educationManager.quiz.isEmpty ? "" : educationManager.quiz[ind].quizName.prefix(1))
-                                        .fontWeight(.bold)
-                                        .font(.largeTitle)
-                                        .padding(.bottom, 10)
-                                        .foregroundColor(.clear)
-                                        .underline(true, color: Color(uiColor: .label))
-                                        .offset(y: 8)
-                                    Text(educationManager.quiz.isEmpty ? "" : educationManager.quiz[ind].quizName)
-                                        .fontWeight(.bold)
-                                        .font(.largeTitle)
-                                        .foregroundColor(Color(uiColor: .label))
-                                }
-                                
-                                Spacer()
-                            }
-                            .padding(.vertical, 8)
-                            .overlay {
-                                RoundedRectangle(cornerRadius: 16)
-                                    .strokeBorder(Color(uiColor: .systemFill) , lineWidth: 8)
-                            }
-                            .padding(.bottom, 12)
-                            
-                            VStack{
-                                ForEach(0..<optionAlphabet.count, id: \.self) { index in
-                                    let optionColor = fetchOptionColor(index: index)
-                                    
-                                    ZStack{
-                                        HStack(spacing: 20){
-                                            Circle()
-                                                .strokeBorder(.blue, lineWidth: 3)
-                                                .frame(width: 20, height: 20)
-                                                .overlay {
-                                                    Circle()
-                                                        .frame(width: 20, height: 20)
-                                                        .foregroundColor(optionColor.circle)
-                                                }
-                                            ZStack{
-                                                Text("[")
-                                                    .fontWeight(.bold)
-                                                    .font(.title2)
-                                                    .foregroundColor(optionColor.bracket)
-                                                +
-                                                Text("\(String(optionAlphabet[index]))")
-                                                    .fontWeight(.bold)
-                                                    .font(.title2)
-                                                    .foregroundColor(optionColor.text)
-                                                +
-                                                Text("]")
-                                                    .fontWeight(.bold)
-                                                    .font(.title2)
-                                                    .foregroundColor(optionColor.bracket)
-                                            }
-                                            Spacer()
-                                        }
-                                        .padding()
-                                    }
-                                    .overlay(RoundedRectangle(cornerRadius: 15.0)
-                                        .stroke(optionColor.border, lineWidth: 4))
-                                    .onTapGesture {
-                                        if !isOptionSubmitted {
-                                            selectedOptionIndex = index
-                                            isOptionSelected = true
-                                        }
-                                        if String(optionAlphabet[index]) == educationManager.quiz[ind].quizName {
-                                            answerIndex = index
-                                        }
-                                        
-                                    }
-                                    .onAppear {
-                                        if String(optionAlphabet[index]) == educationManager.quiz[ind].quizName  {
-                                            answerIndex = index
-                                        }
-                                    }
-                                    .onChange(of: isOptionSubmitted) { _ in
-                                        if answerIndex != selectedOptionIndex && isOptionSubmitted {
-                                            isOptionWrong = true
-                                        }
-                                        
-                                    }
-                                }
-                            }
-                            
-                            Spacer()
-                            
-                            Rectangle()
-                                .frame(height: 200)
-                                .foregroundColor(.clear)
-                            
-                            Rectangle()
-                                .frame(height: 1)
-                                .foregroundColor(.clear)
-                                .id(bottomID)
+                            Image("국밥")
+                                .resizable()
+                                .scaledToFit()
                         }
-
+                        .frame(maxWidth: .infinity, maxHeight: UIScreen.main.bounds.height * 0.2)
+                        .background(Color(uiColor: .quaternarySystemFill))
+                        
+                        //                            HStack{
+                        //                                Spacer()
+                        //
+                        //                                ZStack(alignment: .leading) {
+                        //                                    Text(educationManager.quiz.isEmpty ? "" : educationManager.quiz[ind].quizName.prefix(1))
+                        //                                        .fontWeight(.bold)
+                        //                                        .font(.largeTitle)
+                        //                                        .padding(.bottom, 10)
+                        //                                        .foregroundColor(.clear)
+                        //                                        .underline(true, color: Color(uiColor: .label))
+                        //                                        .offset(y: 8)
+                        //                                    Text(educationManager.quiz.isEmpty ? "" : educationManager.quiz[ind].quizName)
+                        //                                        .fontWeight(.bold)
+                        //                                        .font(.largeTitle)
+                        //                                        .foregroundColor(Color(uiColor: .label))
+                        //                                }
+                        //
+                        //                                Spacer()
+                        //                            }
+                        //                            .padding(.vertical, 8)
+                        //                            .overlay {
+                        //                                RoundedRectangle(cornerRadius: 16)
+                        //                                    .strokeBorder(Color(uiColor: .systemFill) , lineWidth: 8)
+                        //                            }
+                        //                            .padding(.bottom, 12)
+                        
+                        LazyVGrid(columns: [GridItem(.flexible(),spacing: 16),GridItem(.flexible(),spacing: 16)], spacing: 16, content: {
+                            ForEach(0..<optionAlphabet.count, id: \.self) { index in
+                                let optionColor = fetchOptionColor(index: index)
+                                
+                                ZStack{
+                                    HStack(spacing: 20){
+                                        Circle()
+                                            .strokeBorder(.blue, lineWidth: 3)
+                                            .frame(width: 20, height: 20)
+                                            .overlay {
+                                                Circle()
+                                                    .frame(width: 20, height: 20)
+                                                    .foregroundColor(optionColor.circle)
+                                            }
+                                        
+                                        Image(systemName: "speaker.wave.2.fill")
+                                            .bold()
+                                            .font(.title2)
+                                            .foregroundColor(optionColor.text)
+                                        
+                                        Spacer()
+                                    }
+                                    .padding()
+                                }
+                                .overlay(RoundedRectangle(cornerRadius: 15.0)
+                                    .stroke(optionColor.border, lineWidth: 4))
+                                .onTapGesture {
+                                    if !isOptionSubmitted {
+                                        selectedOptionIndex = index
+                                        isOptionSelected = true
+                                    }
+                                    if String(optionAlphabet[index]) == educationManager.quiz[ind].quizName {
+                                        answerIndex = index
+                                    }
+                                    
+                                }
+                                .onAppear {
+                                    if String(optionAlphabet[index]) == educationManager.quiz[ind].quizName  {
+                                        answerIndex = index
+                                    }
+                                }
+                                .onChange(of: isOptionSubmitted) { _ in
+                                    if answerIndex != selectedOptionIndex && isOptionSubmitted {
+                                        isOptionWrong = true
+                                    }
+                                    
+                                }
+                            }
+                        })
+                        
+                        Spacer()
+                        
+                        Rectangle()
+                            .frame(height: 200)
+                            .foregroundColor(.clear)
+                        
+                        Rectangle()
+                            .frame(height: 1)
+                            .foregroundColor(.clear)
+                            .id(bottomID)
+                        
+                        
                         
                     }
                     .padding(.horizontal, 16)
@@ -189,11 +189,11 @@ struct HangulQuizView: View {
                             .foregroundStyle(.ultraThinMaterial)
                             .frame(height: UIScreen.main.bounds.height * 0.15)
                     }
-                        .ignoresSafeArea(edges: .bottom)
+                    .ignoresSafeArea(edges: .bottom)
                     
                     if (isOptionSubmitted) {
-                            answerBox()
-                                .transition(.move(edge: .bottom))
+                        answerBox()
+                            .transition(.move(edge: .bottom))
                     }
                     
                     VStack {
@@ -204,14 +204,14 @@ struct HangulQuizView: View {
                                 if quizButtonText == "Check" {
                                     DispatchQueue.global().async {
                                         quizButtonText = "Got it"
-
+                                        
                                     }
                                     DispatchQueue.global().async {
                                         withAnimation {
                                             isOptionSubmitted = true
                                         }
                                     }
-                                                                        
+                                    
                                     return
                                 }
                                 else {
@@ -256,8 +256,8 @@ struct HangulQuizView: View {
                                         
                                         if educationManager.quiz.isEmpty {
                                             educationManager.currentEducation = .end
-//                                            educationManager.endLesson()
-//                                            isPresented.toggle()
+                                            //                                            educationManager.endLesson()
+                                            //                                            isPresented.toggle()
                                         }
                                         else {
                                             withAnimation {
@@ -289,7 +289,7 @@ struct HangulQuizView: View {
                             .padding(.bottom, 48)
                         }
                     }
-                        .ignoresSafeArea(edges: .bottom)
+                    .ignoresSafeArea(edges: .bottom)
                 }
             }
         }


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->
- QuizView의 UI를 변경합니다.
- 작업 이슈: #137 

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->
- 이미지 추가
- 보기 UI 텍스트에서 sf symbol로 변경
- 모음의 보기가 2개만 나타나는 버그 해결

## Logic
<!-- 작업 내용 1 -->
```swift
else if Constants.Hangul.vowels.contains(name) {
            let quizName  = Constants.Hangul.vowelQuiz[name]?[0]

            self.lessonType = lessonType
            self.name = name
            self.sound = Constants.Hangul.vowelSound[name] ?? ""
            self.quizName = Constants.Hangul.vowelQuiz[name]?[lessonType == .lesson ? 0 : 1] ?? ""
            self.options = Constants.HangulQuiz.options[quizName ?? ""] ?? [""]
            self.meaning = Constants.HangulQuiz.meaning[quizName ?? ""] ?? ""
            self.tmi = Constants.HangulQuiz.tmi[quizName ?? ""] ?? ""
        }
```
기존에 quizName이 모두 consonantQuiz로 설정되어 있어서 분기 처리 해주었습니다.

 ## 작업 결과(이미지 첨부는 선택)
<img width="439" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team3-BluePeriodClub/assets/58865827/8cbe3fcf-d9a3-4f1b-8bba-95b9e2571b21">

