### PR TITLE
[Feat/#139] Add Tip in Vowel Card View

### DIFF
--- a/Orum/Orum/Views/Components/BatchimExplainView.swift
+++ b/Orum/Orum/Views/Components/BatchimExplainView.swift
@@ -9,7 +9,7 @@ import SwiftUI
 
 struct BatchimExplainView: View {
     
-    var explainTitle : String
+    var explainTitle : LocalizedStringKey
     var explain : String
     
     var body: some View {

--- a/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Learning/BasicVowelCheckView.swift
+++ b/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Learning/BasicVowelCheckView.swift
@@ -52,7 +52,7 @@ struct BasicVowelCheckView: View {
                         .bold()
                         .font(.largeTitle)
                     
-                    BatchimExplainView(explainTitle: str.concatArray(isComma: true), explain: strExplain)
+                    BatchimExplainView(explainTitle: "\(str.concatArray(isComma: true))", explain: strExplain)
                         
                     
                     LazyVGrid(columns: [GridItem(.flexible(), spacing: 16), GridItem(.flexible(), spacing: 16)], content: {

--- a/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Learning/BatchimLearningView.swift
+++ b/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Learning/BatchimLearningView.swift
@@ -45,7 +45,7 @@ struct BatchimLearningView: View {
                             .multilineTextAlignment(.center)
                         
                         BatchimExplainView(
-                            explainTitle: Constants.Hangul.batchimExplainTitle[lessonName]![pageIndex],
+                            explainTitle: "\( Constants.Hangul.batchimExplainTitle[lessonName]![pageIndex])",
                             explain: Constants.Hangul.batchimExplain[lessonName]![pageIndex])
                         
                         if ((Constants.Hangul.batchimCardCount[lessonName]?[pageIndex])! > 1) {

--- a/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Learning/HangulEducationLearningView.swift
+++ b/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Learning/HangulEducationLearningView.swift
@@ -46,6 +46,10 @@ struct HangulEducationLearningView: View {
                                 .multilineTextAlignment(.center)
                         }
                         
+                        if educationManager.nowStudying == Constants.Lesson.vowel1 && educationManager.index == 0 {
+                            BatchimExplainView(explainTitle: "\(Image(systemName: "lightbulb.max")) Tip" , explain: "The closest pronunciation in English to the given word, and listen carefully to the Korean pronunciation below")
+                                .padding(.bottom, 30)
+                        }                        
                         
                         VStack(spacing: 25){
                             HangulCardView(onTapGesture: {

--- a/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Recap/HangulEducationRecapView.swift
+++ b/Orum/Orum/Views/Tabs/Learning/HangulEducation/LearningLesson/Recap/HangulEducationRecapView.swift
@@ -43,7 +43,7 @@ struct HangulEducationRecapView: View {
                     if educationManager.chapterType == .batchim {
                         
                         ForEach(0 ..< 2){ index in
-                            BatchimExplainView(explainTitle: Constants.Hangul.batchimExplainTitle[lessonName]![index], explain: Constants.Hangul.batchimExplain[lessonName]![index])
+                            BatchimExplainView(explainTitle: "\( Constants.Hangul.batchimExplainTitle[lessonName]![index])", explain: Constants.Hangul.batchimExplain[lessonName]![index])
                         }
                         
                     } else {


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->
- 기본 모음 'ㅡ' 화면에 Tip Component를 추가하였습니다.
- 작업 이슈: #139 

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->
- 기본 모음뷰에 Tip Component 추가

## Logic
<!-- 작업 내용 1 -->
```swift
struct BatchimExplainView: View {
    
    var explainTitle : LocalizedStringKey
```
기존의 BatchimExplainView를 활용하여 SF Symbols이 추가된 title을 사용하기 위해서 explainTitle의 type을 String에서 LocalizedStringKey로 변경해주었습니다.

 ## 작업 결과(이미지 첨부는 선택)
<img width="461" alt="image" src="https://github.com/DeveloperAcademy-POSTECH/MacC-Team3-BluePeriodClub/assets/58865827/a0166d56-f245-4a1b-ac8a-6709e12b07ac">

