### PR TITLE
[Feat/#145] Add Batchim Card Back side

### DIFF
--- a/Orum/Orum/Models/HangulCard.swift
+++ b/Orum/Orum/Models/HangulCard.swift
@@ -18,6 +18,7 @@ struct HangulCard: Hashable {
     var strokeCount : Int = 1
     var chapterType : ChapterType = .system
     var hangulType : HangulType = .single
+    var batchimType: BatchimType?
     
     init(name: String) {
         self.name = name
@@ -51,6 +52,15 @@ struct HangulCard: Hashable {
         }
         
         else { // 받침
+            if name == "ㄱb" || name == "ㄴb" || name == "ㄷb" || name == "ㄹb" || name == "ㅁb" || name == "ㅂb" {
+                self.batchimType = .basic
+            }
+            else if name == "ㅇb" {
+                self.batchimType = .eung
+            }
+            else {
+                self.batchimType = .change
+            }
             self.sound = Constants.Hangul.batchimSound[name] ?? ""
             self.chapterType = .batchim
             self.lottieName = Constants.Hangul.lottieName[Constants.Hangul.batchimEndingRule[name]!] ?? ""
@@ -63,6 +73,10 @@ enum HangulType {
 
 enum CardType {
     case small, medium, large
+}
+
+enum BatchimType {
+    case basic, eung, change
 }
 
 extension CardType {
@@ -155,7 +169,7 @@ extension CardType {
         }
     }
     
-    func explanationFont( _ chapterType : ChapterType, hangulType: HangulType) -> Font {
+    func explanationFont( _ chapterType : ChapterType, hangulType: HangulType = .single) -> Font {
         switch self {
         case .small:
             if chapterType == .consonant {

--- a/Orum/Orum/Views/Components/HangulCardView.swift
+++ b/Orum/Orum/Views/Components/HangulCardView.swift
@@ -36,12 +36,10 @@ struct HangulCardView: View {
     
     var body: some View {
         ZStack{
-            
             HStack{
-                
                 Spacer()
                 
-                VStack(spacing: cardType.imageMeaningSpacing){
+                VStack(spacing: cardType.imageMeaningSpacing) {
                     if !isFlipped {
                         
                         Image(hangulCard.name)
@@ -62,12 +60,16 @@ struct HangulCardView: View {
                             .font( cardType.font )
                             .foregroundColor(Color(uiColor: .systemGray4))
                         
-                    } else {
-                        if hangulCard.chapterType == .consonant || hangulCard.chapterType == .batchim {
+                    }
+                    else {
+                        switch hangulCard.chapterType {
+                        case .system:
+                            EmptyView()
+                            
+                        case .consonant:
                             if hangulCard.hangulType == .single {
                                 LottieView(fileName: hangulCard.lottieName)
                                     .frame(width: cardType.imageFrame, height: cardType.imageFrame)
-                                //                                    .scaleEffect(x: -1, y: 1)
                                 HStack {
                                     Spacer()
                                     
@@ -76,15 +78,14 @@ struct HangulCardView: View {
                                         .font(cardType.explanationFont(.consonant, hangulType: .single))
                                         .foregroundColor(Color(uiColor: .systemGray4))
                                     +
-                                    Text(hangulCard.name == "ㅇb" ? hangulCard.lottieName.prefix(5) : hangulCard.lottieName.prefix(1))
+                                    Text(hangulCard.lottieName.prefix(1))
                                         .fontWeight(.bold)
                                         .font(cardType.explanationFont(.consonant, hangulType: .single))
-                                        .foregroundColor(hangulCard.name == "ㅇb" ? Color(uiColor: .systemGray4) : .primary)
                                     +
-                                    Text(hangulCard.name == "ㅇb" ? hangulCard.lottieName.dropFirst(5) : hangulCard.lottieName.dropFirst(1))
+                                    Text(hangulCard.lottieName.dropFirst(1))
                                         .fontWeight(.bold)
                                         .font(cardType.explanationFont(.consonant, hangulType: .single))
-                                        .foregroundColor(hangulCard.name == "ㅇb" ? .primary : Color(uiColor: .systemGray4))
+                                        .foregroundColor(Color(uiColor: .systemGray4))
                                     +
                                     Text("]")
                                         .fontWeight(.bold)
@@ -93,52 +94,66 @@ struct HangulCardView: View {
                                     
                                     Spacer()
                                 }
-                                //                                .scaleEffect(x: -1, y: 1)
-                            } else {
+                            } 
+                            else {
                                 HStack{
                                     Text("Pronounce '\(hangulCard.explanation)' with a strong empahsis.")
                                         .bold()
                                         .font(cardType.explanationFont(.consonant, hangulType: .double))
                                 }
                                 .frame(width: cardType.imageFrame)
-                                //                                .scaleEffect(x: -1, y: 1)
                                 .multilineTextAlignment(.center)
                             }
-                        }
-                        
-                        else if hangulCard.chapterType == .vowel  {
-                            HStack{
-                                if hangulCard.hangulType == .single {
-                                    TextWithColoredCharacters(text: hangulCard.explanation, targetCharacter: basicVowel, color: .blue)
-                                        .bold()
-                                        .font(cardType.explanationFont(.vowel, hangulType: .single))
-//                                        .font(.largeTitle)
-                                    
-                                    
-                                } else {
-                                    Text("\(hangulCard.explanation)")
-                                        .bold()
-                                        .font(cardType.explanationFont(.consonant, hangulType: .double))
-//                                        .font(.largeTitle)
+                            
+                        case .vowel:
+                                HStack {
+                                    if hangulCard.hangulType == .single {
+                                        TextWithColoredCharacters(text: hangulCard.explanation, targetCharacter: basicVowel, color: .blue)
+                                            .bold()
+                                            .font(cardType.explanationFont(.vowel, hangulType: .single))
+                                    } 
+                                    else {
+                                        Text("\(hangulCard.explanation)")
+                                            .bold()
+                                            .font(cardType.explanationFont(.consonant, hangulType: .double))
+                                    }
                                 }
-                            }
-                            .frame(width: cardType.imageFrame)
-                            //                            .scaleEffect(x: -1, y: 1)
-                            .multilineTextAlignment(.center)
+                                .frame(width: cardType.imageFrame)
+                                .multilineTextAlignment(.center)
                             
-                        } else {
-                            Rectangle()
-                                .foregroundStyle(.clear)
-                                .border(.black)
-                                .frame(width: cardType.imageFrame , height: cardType.imageFrame)
-                            //                                .scaleEffect(x: -1, y: 1)
-                            
-                            Text("[]")
-                                .bold()
-                                .font(cardType.explanationFont(.consonant, hangulType: .single))
-                            //                                .scaleEffect(x: -1, y: 1)
+                        case .batchim:
+                                switch hangulCard.batchimType {
+                                case .basic:
+                                    Text(hangulCard.name.prefix(1))
+                                        .bold()
+                                        .font(cardType.explanationFont(.batchim))
+                                    +
+                                    Text(" does not change in the final position")
+                                        .bold()
+                                        .font(cardType.explanationFont(.batchim))
+
+                                case .eung:
+                                    Text(hangulCard.name.prefix(1))
+                                        .bold()
+                                        .font(cardType.explanationFont(.batchim))
+                                    +
+                                    Text(" changes to [ng] in the final position")
+                                        .bold()
+                                        .font(cardType.explanationFont(.batchim))
+                                
+                                case .change:
+                                    Text(hangulCard.name.prefix(1))
+                                        .bold()
+                                        .font(cardType.explanationFont(.batchim))
+                                    +
+                                    Text(" changes to [\(Constants.Hangul.batchimEndingRule[hangulCard.name]!)] in the final position")
+                                        .bold()
+                                        .font(cardType.explanationFont(.batchim))
+
+                                case nil:
+                                    EmptyView()
+                                }
                         }
-                        
                     }
                 }
                 .frame(minHeight : cardType.maxHeight, maxHeight: cardType.maxHeight)
@@ -150,9 +165,6 @@ struct HangulCardView: View {
             .strokeBorder(isOnceFlipped ? Color(uiColor: .systemGray4) : .blue , lineWidth: cardType.borderWidth))
         .rotation3DEffect(.degrees(contentRotation), axis: (0, 1, 0))
         .rotation3DEffect(.degrees(flashCardRotation), axis: (0, 1, 0))
-        //        .rotation3DEffect(isFlipped ? Angle(degrees: 180) : .zero,
-        //                          axis: (x: 0.0, y: 1.0, z: 0.0))
-        //        .animation(.easeInOut(duration: 0.5), value: isFlipped)
         .contentShape(Rectangle())
         .gesture(
             TapGesture()
@@ -228,7 +240,7 @@ struct TextWithColoredCharacters: View {
 }
 
 #Preview {
-    HangulCardView(onTapGesture: {},hangulCard: HangulUnitEnum.consonant4[0], cardType: .large, canBorderColorChange: true)
-        .environmentObject(EducationManager())
+        HangulCardView(onTapGesture: {},hangulCard: HangulUnitEnum.consonant1[0], cardType: .large, canBorderColorChange: true)
+            .environmentObject(EducationManager())
 }
 


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->
- 받침 카드의 뒷면을 추가했습니다.
- 작업 이슈: #145

## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->

- 받침 카드 뒷면 추가

## Logic
<!-- 작업 내용 1 -->
```swift
struct HangulCard: Hashable {
    let name : String
    let sound : String
    var example1: String = ""
    var example2: String = ""
    var lottieName : String = ""
    var explanation : String = ""
    var strokeCount : Int = 1
    var chapterType : ChapterType = .system
    var hangulType : HangulType = .single
    var batchimType: BatchimType?
 ... 
if name == "ㄱb" || name == "ㄴb" || name == "ㄷb" || name == "ㄹb" || name == "ㅁb" || name == "ㅂb" {
                self.batchimType = .basic
            }
            else if name == "ㅇb" {
                self.batchimType = .eung
            }
            else {
                self.batchimType = .change
            }
```
HangulCard에 batchimType을 옵셔널 변수로 추가해주어 각 조건에 맞게 분기 처리 해주었습니다.

 ## 작업 결과(이미지 첨부는 선택)
![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team3-BluePeriodClub/assets/58865827/c0c19cbb-b546-4a4d-996b-9e1a4ae36e71)
![image](https://github.com/DeveloperAcademy-POSTECH/MacC-Team3-BluePeriodClub/assets/58865827/1839bcbd-4f42-4f1d-b94b-84b2e5eba858)



