### PR TITLE
[Feat/#182] 무음모드에서도 소리를 들을 수 있도록 구현하였습니다

### DIFF
--- a/Orum/Orum/ViewModels/SoundManager.swift
+++ b/Orum/Orum/ViewModels/SoundManager.swift
@@ -7,11 +7,26 @@
 
 import SwiftUI
 import AVKit
+import AVFoundation
 
 class SoundManager: NSObject, AVAudioPlayerDelegate {
     static let instance = SoundManager()
     var player: AVAudioPlayer?
     var completion: (() -> Void)?
+    
+    override private init() {
+            super.init()
+            setupAudioSession()
+        }
+    
+    private func setupAudioSession() {
+        do {
+            try AVAudioSession.sharedInstance().setCategory(.playback, mode: .default, options: [.mixWithOthers])
+            try AVAudioSession.sharedInstance().setActive(true)
+        } catch {
+            print("Failed to set up AVAudioSession: \(error.localizedDescription)")
+        }
+    }
 
     func playSound(sound: String, completion: (() -> Void)?) {
         guard let url = Bundle.main.url(forResource: sound, withExtension: ".m4a") else { return }

--- a/Orum/Orum/Views/Components/Canvas.swift
+++ b/Orum/Orum/Views/Components/Canvas.swift
@@ -160,9 +160,9 @@ class FallingViewController : UIViewController, UITextFieldDelegate, PKCanvasVie
             imageView.removeFromSuperview()
         }
         canvasItems.removeAll()
-        animator.removeBehavior(gravity)
-        animator.removeBehavior(collision)
-        HapticManager.shared.hapticNotification(type: .warning)
+        animator.removeAllBehaviors()
+        
+        HapticManager.shared.hapticNotification(type: .success)
     }
     
     override func viewDidDisappear(_ animated: Bool) {
@@ -170,8 +170,8 @@ class FallingViewController : UIViewController, UITextFieldDelegate, PKCanvasVie
             imageView.removeFromSuperview()
         }
         canvasItems.removeAll()
-        animator.removeBehavior(gravity)
-        animator.removeBehavior(collision)
+        animator.removeAllBehaviors()
+
     }
     
     


### PR DESCRIPTION
## 개요 및 관련 이슈
<!--
- 메인 홈 뷰의 UI를 전체 구현했습니다.(예시)
- 작업 이슈: #1
-->

무음모드에서도 소리를 들을 수 있도록 구현하였습니다
모음을 쓰는 뷰에서 알 수 없는 화면 튕김 에러를 픽스하였습니다


## 작업 사항
<!--
- 관리자용 대시보드 구현(예시)
- 관리자용 권한 수정 버튼 추가(예시)
-->

## Logic
<!-- 작업 내용 1 -->
```swift
    animator.removeBehavior(gravity)
    animator.removeBehavior(collision)
```
글씨를 쓰기 전에는 gravity나 Collision 이 nil인데,
viewDidDisappear 시에 nil 값을 removeBehavior 하려고 해서 튕기는 현상이 발생했습니다.
현재는 .removeAllBehaviors() 메소드를 이용해
모든 behavior 를 제거하도록 수정하였습니다

 ## 작업 결과(이미지 첨부는 선택)
